### PR TITLE
build: update YuanRong artifact sources

### DIFF
--- a/builder/node.Dockerfile
+++ b/builder/node.Dockerfile
@@ -126,16 +126,18 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
 
 ENV YR_INSTALLATION_DIR=/home/yuanrong
 
-# Download and unpack the openyuanrong runtime tarball from the OBS release
-# bucket. The tarball's top-level openyuanrong/ directory is stripped so its
-# contents land directly under HOME. The Python SDK is intentionally not
-# installed in this image.
-RUN mkdir -p "${YR_INSTALLATION_DIR}" && \
-    curl -fSL --retry 10 --retry-delay 2 --retry-all-errors \
-      -o /tmp/openyuanrong.tar.gz \
-      "https://openyuanrong.obs.cn-southwest-2.myhuaweicloud.com/release/${OPEN_YR_VERSION}/linux/amd64/openyuanrong-${OPEN_YR_VERSION}.tar.gz" && \
-    tar -xzf /tmp/openyuanrong.tar.gz -C "${YR_INSTALLATION_DIR}" --strip-components=1 && \
-    rm -f /tmp/openyuanrong.tar.gz && \
+# Download and unpack the openyuanrong runtime tarball from the GitHub
+# release mirror. The .sha256 sidecar verifies the download before unpacking.
+RUN mkdir -p "${YR_INSTALLATION_DIR}" /tmp/yr-release && \
+    cd /tmp/yr-release && \
+    yr_tarball="openyuanrong-${OPEN_YR_VERSION}-linux-amd64.tar.gz" && \
+    curl -fSL --retry 10 --retry-delay 2 --retry-all-errors -O \
+      "https://github.com/openYuanrong-mirror/yuanrong/releases/download/${OPEN_YR_VERSION}/${yr_tarball}" && \
+    curl -fSL --retry 10 --retry-delay 2 --retry-all-errors -O \
+      "https://github.com/openYuanrong-mirror/yuanrong/releases/download/${OPEN_YR_VERSION}/${yr_tarball}.sha256" && \
+    sha256sum -c "${yr_tarball}.sha256" && \
+    tar -xzf "${yr_tarball}" -C "${YR_INSTALLATION_DIR}" --strip-components=1 && \
+    cd / && rm -rf /tmp/yr-release && \
     ln -sf "${YR_INSTALLATION_DIR}/functionsystem/bin/yr" /usr/bin/yr
 
 COPY --from=runtime-image /yr-runtime-rootfs.img ${YR_INSTALLATION_DIR}/yr-runtime-rootfs.img

--- a/builder/runtime.Dockerfile
+++ b/builder/runtime.Dockerfile
@@ -98,11 +98,6 @@ RUN set -eux; \
 
 RUN set -eux; \
     py="3.10"; version="${PYTHON_310_VERSION}"; \
-    cp_tag="cp$(printf '%s' "${py}" | tr -d '.')"; \
-    wheel="/tmp/openyuanrong_sdk-${OPEN_YR_VERSION}-${cp_tag}-${cp_tag}-manylinux_2_31_x86_64.whl"; \
-    curl -fSL --retry 5 --retry-delay 2 \
-        -o "${wheel}" \
-        "https://openyuanrong.obs.cn-southwest-2.myhuaweicloud.com/release/${OPEN_YR_VERSION}/linux/amd64/openyuanrong_sdk-${OPEN_YR_VERSION}-${cp_tag}-${cp_tag}-manylinux_2_31_x86_64.whl"; \
     attempt=1; \
     while true; do \
         uv pip install \
@@ -112,7 +107,7 @@ RUN set -eux; \
             "fastapi==${FASTAPI_VERSION}" \
             "pydantic==${PYDANTIC_VERSION}" \
             "uvicorn==${UVICORN_VERSION}" \
-            "${wheel}" && break; \
+            "openyuanrong_sdk==${OPEN_YR_VERSION}" && break; \
         if [ "${attempt}" -ge 3 ]; then exit 1; fi; \
         sleep $((attempt * 5)); \
         attempt=$((attempt + 1)); \
@@ -120,16 +115,10 @@ RUN set -eux; \
     ln -sfn \
         "uv-python/cpython-${version}-linux-x86_64-gnu/bin/python${py}" \
         "/opt/python${py}"; \
-    rm -f "${wheel}"; \
     rm -rf "${UV_CACHE_DIR:-/tmp/uv-cache}"
 
 RUN set -eux; \
     py="3.11"; version="${PYTHON_311_VERSION}"; \
-    cp_tag="cp$(printf '%s' "${py}" | tr -d '.')"; \
-    wheel="/tmp/openyuanrong_sdk-${OPEN_YR_VERSION}-${cp_tag}-${cp_tag}-manylinux_2_31_x86_64.whl"; \
-    curl -fSL --retry 5 --retry-delay 2 \
-        -o "${wheel}" \
-        "https://openyuanrong.obs.cn-southwest-2.myhuaweicloud.com/release/${OPEN_YR_VERSION}/linux/amd64/openyuanrong_sdk-${OPEN_YR_VERSION}-${cp_tag}-${cp_tag}-manylinux_2_31_x86_64.whl"; \
     attempt=1; \
     while true; do \
         uv pip install \
@@ -139,7 +128,7 @@ RUN set -eux; \
             "fastapi==${FASTAPI_VERSION}" \
             "pydantic==${PYDANTIC_VERSION}" \
             "uvicorn==${UVICORN_VERSION}" \
-            "${wheel}" && break; \
+            "openyuanrong_sdk==${OPEN_YR_VERSION}" && break; \
         if [ "${attempt}" -ge 3 ]; then exit 1; fi; \
         sleep $((attempt * 5)); \
         attempt=$((attempt + 1)); \
@@ -147,16 +136,10 @@ RUN set -eux; \
     ln -sfn \
         "uv-python/cpython-${version}-linux-x86_64-gnu/bin/python${py}" \
         "/opt/python${py}"; \
-    rm -f "${wheel}"; \
     rm -rf "${UV_CACHE_DIR:-/tmp/uv-cache}"
 
 RUN set -eux; \
     py="3.12"; version="${PYTHON_312_VERSION}"; \
-    cp_tag="cp$(printf '%s' "${py}" | tr -d '.')"; \
-    wheel="/tmp/openyuanrong_sdk-${OPEN_YR_VERSION}-${cp_tag}-${cp_tag}-manylinux_2_31_x86_64.whl"; \
-    curl -fSL --retry 5 --retry-delay 2 \
-        -o "${wheel}" \
-        "https://openyuanrong.obs.cn-southwest-2.myhuaweicloud.com/release/${OPEN_YR_VERSION}/linux/amd64/openyuanrong_sdk-${OPEN_YR_VERSION}-${cp_tag}-${cp_tag}-manylinux_2_31_x86_64.whl"; \
     attempt=1; \
     while true; do \
         uv pip install \
@@ -166,7 +149,7 @@ RUN set -eux; \
             "fastapi==${FASTAPI_VERSION}" \
             "pydantic==${PYDANTIC_VERSION}" \
             "uvicorn==${UVICORN_VERSION}" \
-            "${wheel}" && break; \
+            "openyuanrong_sdk==${OPEN_YR_VERSION}" && break; \
         if [ "${attempt}" -ge 3 ]; then exit 1; fi; \
         sleep $((attempt * 5)); \
         attempt=$((attempt + 1)); \
@@ -174,16 +157,10 @@ RUN set -eux; \
     ln -sfn \
         "uv-python/cpython-${version}-linux-x86_64-gnu/bin/python${py}" \
         "/opt/python${py}"; \
-    rm -f "${wheel}"; \
     rm -rf "${UV_CACHE_DIR:-/tmp/uv-cache}"
 
 RUN set -eux; \
     py="3.13"; version="${PYTHON_313_VERSION}"; \
-    cp_tag="cp$(printf '%s' "${py}" | tr -d '.')"; \
-    wheel="/tmp/openyuanrong_sdk-${OPEN_YR_VERSION}-${cp_tag}-${cp_tag}-manylinux_2_31_x86_64.whl"; \
-    curl -fSL --retry 5 --retry-delay 2 \
-        -o "${wheel}" \
-        "https://openyuanrong.obs.cn-southwest-2.myhuaweicloud.com/release/${OPEN_YR_VERSION}/linux/amd64/openyuanrong_sdk-${OPEN_YR_VERSION}-${cp_tag}-${cp_tag}-manylinux_2_31_x86_64.whl"; \
     attempt=1; \
     while true; do \
         uv pip install \
@@ -193,7 +170,7 @@ RUN set -eux; \
             "fastapi==${FASTAPI_VERSION}" \
             "pydantic==${PYDANTIC_VERSION}" \
             "uvicorn==${UVICORN_VERSION}" \
-            "${wheel}" && break; \
+            "openyuanrong_sdk==${OPEN_YR_VERSION}" && break; \
         if [ "${attempt}" -ge 3 ]; then exit 1; fi; \
         sleep $((attempt * 5)); \
         attempt=$((attempt + 1)); \
@@ -201,7 +178,6 @@ RUN set -eux; \
     ln -sfn \
         "uv-python/cpython-${version}-linux-x86_64-gnu/bin/python${py}" \
         "/opt/python${py}"; \
-    rm -f "${wheel}"; \
     rm -rf "${UV_CACHE_DIR:-/tmp/uv-cache}"
 
 COPY ./builder/scripts/entryfile.sh /home/entryfile.sh


### PR DESCRIPTION
## Summary

- download the openYuanRong runtime archive and SHA-256 sidecar from the GitHub release mirror
- verify the runtime archive before unpacking it into the node image
- install the pinned `openyuanrong_sdk` version through the configured Python package index for Python 3.10 through 3.13

## Why

This removes the direct dependency on ABI-specific SDK wheels and runtime artifacts hosted in the OBS release bucket. Runtime downloads now use the public GitHub mirror with checksum verification, while SDK installation follows the package index already configured for `uv`.

## Impact

Node image builds validate the downloaded runtime archive before extraction. Runtime image builds resolve the same pinned SDK version through the configured Python index instead of hard-coded wheel URLs.

## Validation

- `git diff --check`
