### PR TITLE
fix(sdk): support openyuanrong 0.9.1 copy API

### DIFF
--- a/sdk/python/akernel_sdk/filesystem.py
+++ b/sdk/python/akernel_sdk/filesystem.py
@@ -171,6 +171,8 @@ class Filesystem:
 
     def _cp(self, src: str, dst: str, upload: bool) -> None:
         from yr.cli.exec import (
+            CopyRequest,
+            ExecConnection,
             choose_cp_mode,
             copy_from_remote,
             copy_from_remote_streaming,
@@ -186,35 +188,25 @@ class Filesystem:
             raise FileNotFoundError(f"Local source path not found: {local_path}")
 
         streaming = choose_cp_mode(local_path, remote_path, upload=upload)
+        conn = ExecConnection(
+            host=host,
+            port=port,
+            use_ssl=use_ssl,
+            verify_server=False,
+            token=token,
+        )
+        request = CopyRequest(
+            instance=instance_id,
+            local_path=local_path,
+            remote_path=remote_path,
+        )
 
         if upload:
             fn = copy_to_remote_streaming if streaming else copy_to_remote
-            _run_coroutine(
-                fn(
-                    host=host,
-                    port=port,
-                    instance=instance_id,
-                    local_path=local_path,
-                    remote_path=remote_path,
-                    use_ssl=use_ssl,
-                    verify_server=False,
-                    token=token,
-                )
-            )
         else:
             fn = copy_from_remote_streaming if streaming else copy_from_remote
-            _run_coroutine(
-                fn(
-                    host=host,
-                    port=port,
-                    instance=instance_id,
-                    remote_path=remote_path,
-                    local_path=local_path,
-                    use_ssl=use_ssl,
-                    verify_server=False,
-                    token=token,
-                )
-            )
+
+        _run_coroutine(fn(conn, request))
 
     def copy_from_local(self, local_path: str, remote_path: str) -> None:
         """Copy a local file or directory **into** the sandbox.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "akernel-sdk"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python SDK and CLI for AKernel remote sandboxes"
 readme = "README.md"
 license = "Apache-2.0"
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: System :: Distributed Computing",
 ]
 dependencies = [
-    "openyuanrong-sdk==0.7.51",
+    "openyuanrong-sdk==0.9.1",
     "websockets>=10.0",
 ]
 

--- a/sdk/python/tests/unit/test_filesystem.py
+++ b/sdk/python/tests/unit/test_filesystem.py
@@ -18,6 +18,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from yr.cli.exec import CopyRequest, ExecConnection
+
 from akernel_sdk.filesystem import Filesystem
 from akernel_sdk.types import EntryInfo
 
@@ -97,14 +99,18 @@ class FilesystemTest(unittest.TestCase):
                 asyncio.run(copy_inside_event_loop())
 
         copy_to_remote.assert_awaited_once_with(
-            host="gateway",
-            port="443",
-            instance="sandbox-id",
-            local_path=str(source),
-            remote_path="/tmp/source.txt",
-            use_ssl=True,
-            verify_server=False,
-            token="token",
+            ExecConnection(
+                host="gateway",
+                port="443",
+                use_ssl=True,
+                verify_server=False,
+                token="token",
+            ),
+            CopyRequest(
+                instance="sandbox-id",
+                local_path=str(source),
+                remote_path="/tmp/source.txt",
+            ),
         )
 
 


### PR DESCRIPTION
## Summary

- bump `akernel-sdk` to 0.1.1 and pin `openyuanrong-sdk==0.9.1`
- adapt filesystem upload and download helpers to the new `ExecConnection` and `CopyRequest` API
- update filesystem unit coverage for the new call shape

## Why

The openYuanRong 0.9.1 exec copy helpers accept connection and request objects instead of the keyword-argument interface used by 0.7.51. Without this adaptation, AKernel filesystem copies are incompatible with the updated dependency.

## Impact

Public `Filesystem.copy_from_local` and `Filesystem.copy_to_local` behavior remains unchanged. The implementation now uses the 0.9.1 transport API, and the package version advances to 0.1.1.

## Validation

- 56 SDK unit tests passed on Python 3.12 with `openyuanrong-sdk==0.9.1`
- `ruff check akernel_sdk tests`
- `mypy akernel_sdk`
- built and inspected the 0.1.1 wheel and source distribution