### PR TITLE
build: add YuanRong source submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = src/distill-fs
 	url = https://github.com/akernel-dev/distill-fs.git
 	branch = main
+[submodule "src/yuanrong"]
+	path = src/yuanrong
+	url = https://github.com/openYuanrong-mirror/yuanrong.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ tunnels. The project overview and deployment quick start are in
   filesystem, PTY support, instance plumbing, and CLI helpers.
 - `sdk/python/examples/` - maintained AKernel SDK examples.
 - `sdk/python/tests/` - maintained AKernel SDK tests.
+- `src/yuanrong/` - pinned openYuanRong mirror checkout, including its
+  recursive component submodules.
 - `builder/` - Dockerfiles, service configs, runtime rootfs build, and image
   entrypoint scripts for the public all-in-one image.
 - `deploy/` - Helm charts, standalone scripts, Terraform modules, and


### PR DESCRIPTION
## Summary

- add the openYuanRong mirror as the `src/yuanrong` Git submodule
- pin the YuanRong source tree to the `0.9.1` commit `942c1b03d28ae2dbab0394dccbeb6be6a7252668`
- document the new source layout in `AGENTS.md`

## Why

AKernel needs the YuanRong source tree and its pinned component repositories to be available from a single recursive checkout. Pinning the release gitlink keeps the source aligned with the installed openYuanRong 0.9.1 packages.

## Impact

Running `git submodule update --init --recursive` now initializes YuanRong 0.9.1 together with its matching `datasystem`, `frontend`, `functionsystem`, and `sandbox-sdk` revisions. The parent gitlink is authoritative and does not track YuanRong `master`.

## Validation

- `git submodule sync --recursive`
- `git submodule update --init --recursive`
- `git submodule foreach --recursive 'git fsck --full'`
- `git diff --check origin/main..HEAD`
- verified every commit-message line is at most 72 characters
