### PR TITLE
chore: refresh repository metadata

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "src/sandboxd"]
 	path = src/sandboxd
-	url = https://github.com/akernel-dev/sandboxd.git
-	branch = main
+	url = https://github.com/inclusionAI/sandboxd.git
 [submodule "src/distill-fs"]
 	path = src/distill-fs
-	url = https://github.com/akernel-dev/distill-fs.git
-	branch = main
+	url = https://github.com/inclusionAI/distill-fs.git
 [submodule "src/yuanrong"]
 	path = src/yuanrong
 	url = https://github.com/openYuanrong-mirror/yuanrong.git

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ One all-in-one image, multiple deployment targets — deploy in under 10 minutes
 
 ### Secure Isolation with Extreme Performance
 
-- **40 ms cold start\***: Fork-based launch with lazy loading for near-zero startup latency
-- **Sandbox isolation**: [gVisor](https://github.com/google/gvisor) today, with Kata Containers support\* planned
-- **Checkpoint/Restore\***: Save and restore sandbox state for fast recovery
+- **40 ms cold start**: Fork-based launch with lazy loading for near-zero startup latency
+- **Sandbox isolation**: [gVisor](https://github.com/google/gvisor) today, with Kata Containers support planned
+- **Checkpoint/Restore**: Save and restore sandbox state for fast recovery
 
-\* Planned for an open-source release and not available in AKernel v0.1.0.
+Planned for an open-source release and not available in AKernel v0.1.0.
 
 ### AI-Native Development and Operations
 


### PR DESCRIPTION
## Summary

- point the `sandboxd` and `distill-fs` submodules at their canonical `inclusionAI` repositories
- remove obsolete footnote markers from the project overview

## Why

The previous `akernel-dev` submodule URLs redirect to the current organization and no longer describe the canonical repository locations. The README markers also add unnecessary formatting noise around the availability note.

This makes fresh submodule initialization resolve directly to the maintained repositories and keeps the project overview easier to read. The pinned component revisions are unchanged.

## Validation

- `git submodule sync --recursive`
- `git submodule update --init --recursive`
- `git submodule status --recursive`
- `make SHELL=/bin/bash versions`