### PR TITLE
feat: support ARM64 macOS standalone validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,9 +144,10 @@ make deploy
 make print-env
 ```
 
-AKernel `v0.1.0` node runtime currently requires Linux x86-64 nodes with
-cgroup v1. Do not deploy it to cgroup v2 nodes or assume bootstrap will detect
-an incompatible host before sandboxd starts.
+AKernel's node runtime supports Linux x86-64 and ARM64 nodes with cgroup v1.
+Do not deploy it to cgroup v2 nodes or assume bootstrap will detect an
+incompatible host before sandboxd starts. Apple Silicon development runs the
+ARM64 image inside Docker Desktop's Linux VM rather than natively on macOS.
 
 Dragonfly distribution is optional and disabled by default. Enable it during
 profile generation with `make config INSTALL_DRAGONFLY=true`. This installs the

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-SHELL := /usr/bin/bash
+SHELL := /bin/bash
 
 VENDOR ?= aliyun
 ENV ?= default
@@ -10,6 +10,8 @@ IMAGE_TAG ?=
 IMAGE_REPOSITORY ?=
 GVISOR_RELEASE ?=
 GVISOR_RELEASE_BASE_URL ?=
+OPEN_YR_RELEASE_BASE_URL ?=
+PLATFORM ?=
 TOKEN_TTL ?= $(if $(TTL),$(TTL),24h)
 TENANT ?= default
 ROLE ?= developer
@@ -46,6 +48,7 @@ help:
 	@echo "  make config NON_INTERACTIVE=1 ...  Generate config from Make variables"
 	@echo "  make config INSTALL_DRAGONFLY=true Enable optional P2P image distribution"
 	@echo "  make build IMAGE_TAG=<tag>          Build the all-in-one image"
+	@echo "  make build PLATFORM=linux/arm64     Build for a selected OCI platform"
 	@echo "  make build GVISOR_RELEASE=<tag>     Override the pinned official gVisor tag"
 	@echo "  make versions                       Show locally selected component versions"
 	@echo "  make push                          Push the configured all-in-one image"
@@ -95,8 +98,10 @@ build:
 	args=(--env "$(ENV)"); \
 	if [[ -n "$(IMAGE_REPOSITORY)" ]]; then args+=(--repository "$(IMAGE_REPOSITORY)"); fi; \
 	if [[ -n "$(IMAGE_TAG)" ]]; then args+=(--tag "$(IMAGE_TAG)"); fi; \
+	if [[ -n "$(PLATFORM)" ]]; then args+=(--platform "$(PLATFORM)"); fi; \
 	if [[ -n "$(GVISOR_RELEASE)" ]]; then args+=(--gvisor-release "$(GVISOR_RELEASE)"); fi; \
 	if [[ -n "$(GVISOR_RELEASE_BASE_URL)" ]]; then args+=(--gvisor-release-base-url "$(GVISOR_RELEASE_BASE_URL)"); fi; \
+	if [[ -n "$(OPEN_YR_RELEASE_BASE_URL)" ]]; then args+=(--open-yr-release-base-url "$(OPEN_YR_RELEASE_BASE_URL)"); fi; \
 	./deploy/scripts/build-image.sh "$${args[@]}"
 
 .PHONY: versions

--- a/builder/node.Dockerfile
+++ b/builder/node.Dockerfile
@@ -7,10 +7,11 @@ ARG AKERNEL_RUNTIME_IMAGE=akernel-runtime:local
 ARG SANDBOXD_BUILD_IMAGE=golang:1.25.5-bookworm
 ARG DISTILL_FS_BUILD_IMAGE=rust:1.85.0-bookworm
 ARG OPEN_YR_VERSION=0.9.1
+ARG OPEN_YR_RELEASE_BASE_URL=https://github.com/openYuanrong-mirror/yuanrong/releases/download
 ARG GVISOR_RELEASE=release-20260706.0
 ARG GVISOR_RELEASE_BASE_URL=https://storage.googleapis.com/gvisor/releases
 ARG OTELCOL_CONTRIB_VERSION=0.120.0
-ARG OTELCOL_CONTRIB_URL=https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${OTELCOL_CONTRIB_VERSION}/otelcol-contrib_${OTELCOL_CONTRIB_VERSION}_linux_amd64.tar.gz
+ARG OTELCOL_CONTRIB_URL=
 ARG AKERNEL_VERSION=unknown
 ARG AKERNEL_REVISION=unknown
 
@@ -52,8 +53,10 @@ FROM ${AKERNEL_NODE_BASE_IMAGE}
 ARG AKERNEL_VERSION
 ARG AKERNEL_REVISION
 ARG OPEN_YR_VERSION
+ARG OPEN_YR_RELEASE_BASE_URL
 ARG GVISOR_RELEASE
 ARG GVISOR_RELEASE_BASE_URL
+ARG OTELCOL_CONTRIB_VERSION
 ARG OTELCOL_CONTRIB_URL
 ARG TARGETARCH
 ARG PIP_INDEX_URL=https://pypi.org/simple
@@ -90,9 +93,13 @@ RUN if command -v update-alternatives >/dev/null 2>&1; then \
 RUN set -eux; \
     case "${TARGETARCH:-}" in \
         amd64) gvisor_arch="x86_64" ;; \
+        arm64) gvisor_arch="aarch64" ;; \
         "") \
-            [ "$(uname -m)" = "x86_64" ] || { echo "unsupported gVisor target architecture: $(uname -m)" >&2; exit 1; }; \
-            gvisor_arch="x86_64" ;; \
+            case "$(uname -m)" in \
+                x86_64) gvisor_arch="x86_64" ;; \
+                aarch64|arm64) gvisor_arch="aarch64" ;; \
+                *) echo "unsupported gVisor target architecture: $(uname -m)" >&2; exit 1 ;; \
+            esac ;; \
         *) echo "unsupported gVisor target architecture: ${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
     gvisor_version="${GVISOR_RELEASE#release-}"; \
@@ -130,11 +137,16 @@ ENV YR_INSTALLATION_DIR=/home/yuanrong
 # release mirror. The .sha256 sidecar verifies the download before unpacking.
 RUN mkdir -p "${YR_INSTALLATION_DIR}" /tmp/yr-release && \
     cd /tmp/yr-release && \
-    yr_tarball="openyuanrong-${OPEN_YR_VERSION}-linux-amd64.tar.gz" && \
+    case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
+      amd64) artifact_arch="amd64" ;; \
+      arm64) artifact_arch="arm64" ;; \
+      *) echo "unsupported openYuanrong target architecture: ${TARGETARCH:-$(dpkg --print-architecture)}" >&2; exit 1 ;; \
+    esac && \
+    yr_tarball="openyuanrong-${OPEN_YR_VERSION}-linux-${artifact_arch}.tar.gz" && \
     curl -fSL --retry 10 --retry-delay 2 --retry-all-errors -O \
-      "https://github.com/openYuanrong-mirror/yuanrong/releases/download/${OPEN_YR_VERSION}/${yr_tarball}" && \
+      "${OPEN_YR_RELEASE_BASE_URL}/${OPEN_YR_VERSION}/${yr_tarball}" && \
     curl -fSL --retry 10 --retry-delay 2 --retry-all-errors -O \
-      "https://github.com/openYuanrong-mirror/yuanrong/releases/download/${OPEN_YR_VERSION}/${yr_tarball}.sha256" && \
+      "${OPEN_YR_RELEASE_BASE_URL}/${OPEN_YR_VERSION}/${yr_tarball}.sha256" && \
     sha256sum -c "${yr_tarball}.sha256" && \
     tar -xzf "${yr_tarball}" -C "${YR_INSTALLATION_DIR}" --strip-components=1 && \
     cd / && rm -rf /tmp/yr-release && \
@@ -168,8 +180,15 @@ COPY ./builder/scripts/master_entrypoint.sh ${YR_INSTALLATION_DIR}/entrypoint.sh
 COPY ./builder/scripts/*.sh /root/
 COPY ./builder/systemd_services/*.service /etc/systemd/system/
 
-RUN curl -fSL --retry 10 --retry-delay 2 --retry-all-errors \
-        "${OTELCOL_CONTRIB_URL}" \
+RUN set -eux; \
+    case "${TARGETARCH:-$(dpkg --print-architecture)}" in \
+      amd64) artifact_arch="amd64" ;; \
+      arm64) artifact_arch="arm64" ;; \
+      *) echo "unsupported OpenTelemetry target architecture: ${TARGETARCH:-$(dpkg --print-architecture)}" >&2; exit 1 ;; \
+    esac; \
+    otelcol_url="${OTELCOL_CONTRIB_URL:-https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${OTELCOL_CONTRIB_VERSION}/otelcol-contrib_${OTELCOL_CONTRIB_VERSION}_linux_${artifact_arch}.tar.gz}"; \
+    curl -fSL --retry 10 --retry-delay 2 --retry-all-errors \
+        "${otelcol_url}" \
     | tar -xz -C /usr/local/bin otelcol-contrib && \
     chmod 0755 /usr/local/bin/otelcol-contrib
 

--- a/builder/runtime.Dockerfile
+++ b/builder/runtime.Dockerfile
@@ -65,9 +65,11 @@ RUN set -eux; \
         py="${spec%%:*}"; \
         version="${spec#*:}"; \
         uv venv "/opt/venv-py${py}" --python "${version}" --seed; \
-        ln -sfn \
-            "uv-python/cpython-${version}-linux-x86_64-gnu/bin/python${py}" \
-            "/opt/python${py}"; \
+        python_path="$(readlink -f "/opt/venv-py${py}/bin/python")"; \
+        case "${python_path}" in \
+            /opt/*) ln -sfn "${python_path#/opt/}" "/opt/python${py}" ;; \
+            *) echo "unexpected uv Python path: ${python_path}" >&2; exit 1 ;; \
+        esac; \
     done; \
     rm -rf "${UV_CACHE_DIR}"
 
@@ -112,9 +114,11 @@ RUN set -eux; \
         sleep $((attempt * 5)); \
         attempt=$((attempt + 1)); \
     done; \
-    ln -sfn \
-        "uv-python/cpython-${version}-linux-x86_64-gnu/bin/python${py}" \
-        "/opt/python${py}"; \
+    python_path="$(readlink -f "/opt/venv-py${py}/bin/python")"; \
+    case "${python_path}" in \
+        /opt/*) ln -sfn "${python_path#/opt/}" "/opt/python${py}" ;; \
+        *) echo "unexpected uv Python path: ${python_path}" >&2; exit 1 ;; \
+    esac; \
     rm -rf "${UV_CACHE_DIR:-/tmp/uv-cache}"
 
 RUN set -eux; \
@@ -133,9 +137,11 @@ RUN set -eux; \
         sleep $((attempt * 5)); \
         attempt=$((attempt + 1)); \
     done; \
-    ln -sfn \
-        "uv-python/cpython-${version}-linux-x86_64-gnu/bin/python${py}" \
-        "/opt/python${py}"; \
+    python_path="$(readlink -f "/opt/venv-py${py}/bin/python")"; \
+    case "${python_path}" in \
+        /opt/*) ln -sfn "${python_path#/opt/}" "/opt/python${py}" ;; \
+        *) echo "unexpected uv Python path: ${python_path}" >&2; exit 1 ;; \
+    esac; \
     rm -rf "${UV_CACHE_DIR:-/tmp/uv-cache}"
 
 RUN set -eux; \
@@ -154,9 +160,11 @@ RUN set -eux; \
         sleep $((attempt * 5)); \
         attempt=$((attempt + 1)); \
     done; \
-    ln -sfn \
-        "uv-python/cpython-${version}-linux-x86_64-gnu/bin/python${py}" \
-        "/opt/python${py}"; \
+    python_path="$(readlink -f "/opt/venv-py${py}/bin/python")"; \
+    case "${python_path}" in \
+        /opt/*) ln -sfn "${python_path#/opt/}" "/opt/python${py}" ;; \
+        *) echo "unexpected uv Python path: ${python_path}" >&2; exit 1 ;; \
+    esac; \
     rm -rf "${UV_CACHE_DIR:-/tmp/uv-cache}"
 
 RUN set -eux; \
@@ -175,9 +183,11 @@ RUN set -eux; \
         sleep $((attempt * 5)); \
         attempt=$((attempt + 1)); \
     done; \
-    ln -sfn \
-        "uv-python/cpython-${version}-linux-x86_64-gnu/bin/python${py}" \
-        "/opt/python${py}"; \
+    python_path="$(readlink -f "/opt/venv-py${py}/bin/python")"; \
+    case "${python_path}" in \
+        /opt/*) ln -sfn "${python_path#/opt/}" "/opt/python${py}" ;; \
+        *) echo "unexpected uv Python path: ${python_path}" >&2; exit 1 ;; \
+    esac; \
     rm -rf "${UV_CACHE_DIR:-/tmp/uv-cache}"
 
 COPY ./builder/scripts/entryfile.sh /home/entryfile.sh

--- a/builder/scripts/entryfile.sh
+++ b/builder/scripts/entryfile.sh
@@ -8,6 +8,21 @@ set -eu
 
 RUNTIME_ENV=${YR_LANGUAGE:-python3.12}
 
+case "$(uname -m)" in
+    x86_64)
+        MULTIARCH=x86_64-linux-gnu
+        RUNTIME_LOADER=ld-linux-x86-64.so.2
+        ;;
+    aarch64|arm64)
+        MULTIARCH=aarch64-linux-gnu
+        RUNTIME_LOADER=ld-linux-aarch64.so.1
+        ;;
+    *)
+        echo "unsupported runtime architecture: $(uname -m)" >&2
+        exit 127
+        ;;
+esac
+
 case "$RUNTIME_ENV" in
     python3.10)
         PY_VERSION=3.10
@@ -45,10 +60,10 @@ if [ ! -x "${RUNTIME_BIN}" ]; then
     RUNTIME_BIN="${RUNTIME_PREFIX}/opt/venv-py${PY_VERSION}/bin/python"
 fi
 
-RUNTIME_LIBRARY_PATH="${RUNTIME_PREFIX}/usr/lib/x86_64-linux-gnu:${RUNTIME_PREFIX}/usr/local/lib:${RUNTIME_PREFIX}/usr/lib64:${RUNTIME_PREFIX}/lib/x86_64-linux-gnu:${RUNTIME_PREFIX}/lib64:${RUNTIME_PREFIX}/lib"
+RUNTIME_LIBRARY_PATH="${RUNTIME_PREFIX}/usr/lib/${MULTIARCH}:${RUNTIME_PREFIX}/usr/local/lib:${RUNTIME_PREFIX}/usr/lib64:${RUNTIME_PREFIX}/lib/${MULTIARCH}:${RUNTIME_PREFIX}/lib64:${RUNTIME_PREFIX}/lib"
 
 if [ ! -x "${RUNTIME_BIN}" ]; then
-	echo "missing runtime interpreter: ${RUNTIME_BIN}" >&2
+    echo "missing runtime interpreter: ${RUNTIME_BIN}" >&2
     exit 127
 fi
 
@@ -60,10 +75,16 @@ fi
 export PYTHONPATH="${SITE_PACKAGES}${PYTHONPATH:+:${PYTHONPATH}}"
 
 if [ -n "${RUNTIME_PREFIX}" ]; then
-    RUNTIME_LD="${RUNTIME_PREFIX}/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
-    if [ ! -x "${RUNTIME_LD}" ]; then
-        RUNTIME_LD="${RUNTIME_PREFIX}/lib64/ld-linux-x86-64.so.2"
-    fi
+    RUNTIME_LD=""
+    for candidate in \
+        "${RUNTIME_PREFIX}/lib/${MULTIARCH}/${RUNTIME_LOADER}" \
+        "${RUNTIME_PREFIX}/lib64/${RUNTIME_LOADER}" \
+        "${RUNTIME_PREFIX}/lib/${RUNTIME_LOADER}"; do
+        if [ -x "${candidate}" ]; then
+            RUNTIME_LD="${candidate}"
+            break
+        fi
+    done
     if [ ! -x "${RUNTIME_LD}" ]; then
         echo "missing runtime dynamic linker under ${RUNTIME_PREFIX}" >&2
         exit 127
@@ -76,7 +97,7 @@ if [ -n "${RUNTIME_PREFIX}" ]; then
         "$@"
 fi
 
-export LD_LIBRARY_PATH="${RUNTIME_LIBRARY_PATH}:/usr/lib/x86_64-linux-gnu:/usr/local/lib:/usr/lib64:/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+export LD_LIBRARY_PATH="${RUNTIME_LIBRARY_PATH}:/usr/lib/${MULTIARCH}:/usr/local/lib:/usr/lib64:/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 
 exec "${RUNTIME_BIN}" \
     "${SITE_PACKAGES}/yr/main/yr_runtime_main.py" \

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -25,10 +25,11 @@ make print-env
 make e2e
 ```
 
-The current node runtime requires Linux x86-64 with cgroup v1. It does not yet
+The node runtime supports Linux x86-64 and ARM64 with cgroup v1. It does not
 support cgroup v2, and bootstrap does not reliably detect an incompatible host
 before sandboxd starts. Verify the node operating system and cgroup mode before
-deployment.
+deployment. On Apple Silicon, this means running the ARM64 image inside Docker
+Desktop's Linux VM; macOS itself is not a native node target.
 
 `make config` is interactive by default. It writes:
 

--- a/deploy/scripts/build-image.sh
+++ b/deploy/scripts/build-image.sh
@@ -15,8 +15,10 @@ repository=""
 tag=""
 env_name=""
 runtime_image=""
+platform=""
 gvisor_release=""
 gvisor_release_base_url=""
+open_yr_release_base_url=""
 print_component_versions=0
 
 component_revision() {
@@ -77,12 +79,20 @@ while [[ $# -gt 0 ]]; do
       runtime_image="$2"
       shift 2
       ;;
+    --platform)
+      platform="$2"
+      shift 2
+      ;;
     --gvisor-release)
       gvisor_release="$2"
       shift 2
       ;;
     --gvisor-release-base-url)
       gvisor_release_base_url="$2"
+      shift 2
+      ;;
+    --open-yr-release-base-url)
+      open_yr_release_base_url="$2"
       shift 2
       ;;
     --print-component-versions)
@@ -108,6 +118,7 @@ tag="${tag:-$(git -C "${AKERNEL_REPO_ROOT}" rev-parse --short HEAD)-$(date +%Y%m
 
 runtime_image="${runtime_image:-akernel-runtime:${tag}}"
 all_in_one_image="${repository}:${tag}"
+platform="${platform:-${AKERNEL_BUILD_PLATFORM:-}}"
 
 cd "${AKERNEL_REPO_ROOT}"
 
@@ -138,7 +149,12 @@ if [[ "${print_component_versions}" == "1" ]]; then
 fi
 
 info "building ${runtime_image}"
+platform_args=()
+if [[ -n "${platform}" ]]; then
+  platform_args+=(--platform "${platform}")
+fi
 docker build \
+  "${platform_args[@]}" \
   -f builder/runtime.Dockerfile \
   -t "${runtime_image}" \
   .
@@ -155,7 +171,11 @@ fi
 if [[ -n "${gvisor_release_base_url}" ]]; then
   node_build_args+=(--build-arg "GVISOR_RELEASE_BASE_URL=${gvisor_release_base_url}")
 fi
+if [[ -n "${open_yr_release_base_url}" ]]; then
+  node_build_args+=(--build-arg "OPEN_YR_RELEASE_BASE_URL=${open_yr_release_base_url}")
+fi
 docker build \
+  "${platform_args[@]}" \
   -f builder/node.Dockerfile \
   "${node_build_args[@]}" \
   -t "${all_in_one_image}" \

--- a/deploy/standalone/README.md
+++ b/deploy/standalone/README.md
@@ -76,10 +76,18 @@ This will:
 - Start an independent Traefik container for the HTTPS API and HTTP sandbox
   port-forwarding gateway
 - Generate a deployment-specific IAM signing seed and a 24-hour SDK token
-- Print the Traefik container IP to use as `AKERNEL_SERVER_ADDRESS`
+- Print the address to use as `AKERNEL_SERVER_ADDRESS`
 
-No host ports are published. On Linux, the host accesses Traefik directly
-through its Docker bridge IP.
+On Linux, no host ports are published by default and the host accesses Traefik
+through its Docker bridge IP. Docker Desktop on macOS cannot route directly to
+that bridge IP, so `start.sh` automatically publishes ports 80 and 443 on
+`127.0.0.1` and prints `AKERNEL_SERVER_ADDRESS=127.0.0.1`.
+
+Docker Desktop on macOS also uses the `akernel-standalone-data` named volume
+for `/home/akernel`. This avoids a VirtioFS limitation triggered by placing
+individual configuration bind mounts beneath a parent host-directory bind
+mount. Credentials and generated Traefik configuration remain in the ignored
+host-side `data/` directory.
 
 ### 4. Check Status
 
@@ -110,8 +118,8 @@ sudo docker exec akernel-node systemctl status
 ### SDK Connection
 
 Traefik listens on port 443 for the AKernel API and port 80 for sandbox port
-forwarding. These ports are not published on the host. Use the Traefik
-container IP printed by `start.sh`, or retrieve it later:
+forwarding. On Linux, use the Traefik container IP printed by `start.sh`, or
+retrieve it later:
 
 ```bash
 TRAEFIK_IP=$(docker inspect \
@@ -135,13 +143,37 @@ When `AKERNEL_SERVER_ADDRESS` contains only an IP address, the SDK uses HTTPS
 port 443 for the API and HTTP port 80 for sandbox port forwarding. No separate
 `AKERNEL_GATEWAY_ADDRESS` is required.
 
+On macOS, use the host address printed by the script:
+
+```bash
+export AKERNEL_SERVER_ADDRESS=127.0.0.1
+export AKERNEL_TOKEN="$(cat data/token)"
+```
+
+Ports 80 and 443 must be available. Override the automatic behavior with
+`AKERNEL_PUBLISH_HOST_PORTS=true|false`; change the bind address with
+`AKERNEL_HOST_BIND_ADDRESS`. When host ports are enabled, keep them on ports 80
+and 443 because the SDK intentionally uses the same hostname with HTTPS on 443
+and HTTP on 80.
+
 ### Container Image Version
 
 By default, `start.sh` uses the public Docker Hub image
 `akerneldev/all-in-one:latest`. Override it with the `IMAGE` environment
 variable to test another registry, tag, or locally built image:
+
 ```bash
 IMAGE="<your-docker-registry>:<your-tag>" ./start.sh
+```
+
+For a native Apple Silicon development build from the repository root:
+
+```bash
+make build \
+  PLATFORM=linux/arm64 \
+  IMAGE_REPOSITORY=akernel-local/all-in-one \
+  IMAGE_TAG=arm64
+IMAGE=akernel-local/all-in-one:arm64 ./deploy/standalone/start.sh
 ```
 
 The gateway defaults to `traefik:v3.6.8`. Override it independently when
@@ -153,7 +185,22 @@ TRAEFIK_IMAGE="traefik:v3.6.8" ./start.sh
 
 ### Data Directory Location
 
-By default, data is stored in `./data`. To change this, edit `start.sh`:
+By default, credentials and gateway configuration are stored in `./data`.
+Change the host-side directory with:
+
 ```bash
-DATA_DIR="/path/to/your/data"
+AKERNEL_DATA_DIR="/path/to/your/data" ./start.sh
 ```
+
+Set `AKERNEL_DATA_VOLUME` to use a named container volume for AKernel runtime
+state. macOS defaults to `akernel-standalone-data`; Linux defaults to the
+host-side data directory. `stop.sh` removes the containers but deliberately
+retains the named volume.
+
+## Host Requirements
+
+The node container is privileged and uses the host cgroup namespace plus a
+read-write `/sys/fs/cgroup` mount. This supplies the permissions sandboxd needs
+for cgroups, iptables, loop mounts, and gVisor. The Docker Linux VM or native
+Linux host must provide cgroup v1; container privilege cannot substitute for
+the required cgroup version or missing kernel filesystems.

--- a/deploy/standalone/start.sh
+++ b/deploy/standalone/start.sh
@@ -10,7 +10,7 @@ set -e
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_DIR="${SCRIPT_DIR}/config"
-DATA_DIR="${SCRIPT_DIR}/data"
+DATA_DIR="${AKERNEL_DATA_DIR:-${SCRIPT_DIR}/data}"
 FRONTEND_PORT="8888"
 ETCD_PORT="${ETCD_PORT:-2379}"
 ETCD_PEER_PORT="${ETCD_PEER_PORT:-2378}"
@@ -21,11 +21,19 @@ TRAEFIK_IMAGE="${TRAEFIK_IMAGE:-traefik:v3.6.8}"
 IAM_SEED_FILE="${DATA_DIR}/iam-seed"
 TOKEN_FILE="${DATA_DIR}/token"
 LITEBUS_DATA_KEY=""
+DATA_VOLUME="${AKERNEL_DATA_VOLUME:-}"
+PUBLISH_HOST_PORTS="${AKERNEL_PUBLISH_HOST_PORTS:-auto}"
+HOST_BIND_ADDRESS="${AKERNEL_HOST_BIND_ADDRESS:-127.0.0.1}"
+SDK_SERVER_ADDRESS=""
 
 # Container runtime command (docker or pouch)
 DOCKER_CMD=""
 DOCKER_PREFIX=()
 PROXY_RUN_ARGS=()
+NODE_RUNTIME_ARGS=()
+DATA_MOUNT_ARGS=()
+AUTH_MOUNT_ARGS=()
+TRAEFIK_RUN_ARGS=()
 
 # Colors for output
 RED='\033[0;31m'
@@ -116,6 +124,64 @@ check_prerequisites() {
     mkdir -p "${DATA_DIR}/sandboxd/config" "${DATA_DIR}/sandboxd/image_manager"
 
     log_info "All config files found"
+}
+
+configure_local_runtime() {
+    local host_os
+    host_os="$(uname -s)"
+
+    if [[ "${PUBLISH_HOST_PORTS}" == "auto" ]]; then
+        if [[ "${host_os}" == "Darwin" && "${DOCKER_CMD}" == "docker" ]]; then
+            PUBLISH_HOST_PORTS="true"
+        else
+            PUBLISH_HOST_PORTS="false"
+        fi
+    fi
+
+    case "${PUBLISH_HOST_PORTS}" in
+        true|false) ;;
+        *)
+            log_error "AKERNEL_PUBLISH_HOST_PORTS must be auto, true, or false"
+            exit 1
+            ;;
+    esac
+
+    if [[ "${DOCKER_CMD}" == "docker" ]]; then
+        NODE_RUNTIME_ARGS=(
+            --cgroupns=host
+            -v /sys/fs/cgroup:/sys/fs/cgroup:rw
+        )
+    fi
+
+    if [[ -z "${DATA_VOLUME}" && "${host_os}" == "Darwin" && "${DOCKER_CMD}" == "docker" ]]; then
+        DATA_VOLUME="akernel-standalone-data"
+    fi
+
+    if [[ -n "${DATA_VOLUME}" ]]; then
+        if ! "${DOCKER_PREFIX[@]}" ${DOCKER_CMD} volume inspect "${DATA_VOLUME}" &> /dev/null; then
+            "${DOCKER_PREFIX[@]}" ${DOCKER_CMD} volume create "${DATA_VOLUME}" > /dev/null
+            log_info "Created data volume: ${DATA_VOLUME}"
+        else
+            log_info "Using data volume: ${DATA_VOLUME}"
+        fi
+        DATA_MOUNT_ARGS=(-v "${DATA_VOLUME}:/home/akernel")
+        AUTH_MOUNT_ARGS=(-v "${IAM_SEED_FILE}:/home/akernel/iam-seed:ro")
+    else
+        DATA_MOUNT_ARGS=(-v "${DATA_DIR}:/home/akernel")
+    fi
+
+    if [[ "${PUBLISH_HOST_PORTS}" == "true" ]]; then
+        TRAEFIK_RUN_ARGS=(
+            -p "${HOST_BIND_ADDRESS}:80:80"
+            -p "${HOST_BIND_ADDRESS}:443:443"
+        )
+        if [[ "${HOST_BIND_ADDRESS}" == "0.0.0.0" ]]; then
+            SDK_SERVER_ADDRESS="127.0.0.1"
+        else
+            SDK_SERVER_ADDRESS="${HOST_BIND_ADDRESS}"
+        fi
+        log_info "Publishing gateway ports 80 and 443 on ${HOST_BIND_ADDRESS}"
+    fi
 }
 
 configure_auth() {
@@ -209,6 +275,7 @@ start_node_container() {
     "${DOCKER_PREFIX[@]}" ${DOCKER_CMD} run -d \
         --name "${NODE_CONTAINER_NAME}" \
         --privileged \
+        "${NODE_RUNTIME_ARGS[@]}" \
         --net bridge \
         --restart always \
         -e AKS_LOCAL_MODE="true" \
@@ -225,7 +292,8 @@ start_node_container() {
         -e ENABLE_METRICS="${ENABLE_METRICS:-false}" \
         "${PROXY_RUN_ARGS[@]}" \
         --entrypoint=/usr/local/bin/akernel-entrypoint \
-        -v "${DATA_DIR}:/home/akernel" \
+        "${DATA_MOUNT_ARGS[@]}" \
+        "${AUTH_MOUNT_ARGS[@]}" \
         -v "${CONFIG_DIR}/oss_auths.json:/home/akernel/sandboxd/config/oss_auths.json:ro" \
         -v "${CONFIG_DIR}/oss.json:/home/akernel/sandboxd/config/oss.json:ro" \
         -v "${CONFIG_DIR}/registry_auths.json:/home/akernel/sandboxd/config/registry_auths.json:ro" \
@@ -243,13 +311,18 @@ wait_for_ready() {
     local delay=2
 
     for i in $(seq 1 $retries); do
-        if "${DOCKER_PREFIX[@]}" ${DOCKER_CMD} exec "${NODE_CONTAINER_NAME}" systemctl is-system-running &> /dev/null; then
-            log_info "AKernel container is ready"
+        if "${DOCKER_PREFIX[@]}" ${DOCKER_CMD} exec "${NODE_CONTAINER_NAME}" \
+            systemctl is-active --quiet yuanrong.service &> /dev/null && \
+           "${DOCKER_PREFIX[@]}" ${DOCKER_CMD} exec "${NODE_CONTAINER_NAME}" \
+            systemctl is-active --quiet sandboxd.service &> /dev/null; then
+            log_info "AKernel node services are ready"
             return 0
         fi
 
         if [[ $i -eq $retries ]]; then
-            log_warn "AKernel may not be fully ready; check ${DOCKER_CMD} logs ${NODE_CONTAINER_NAME}"
+            log_error "AKernel node services did not become ready"
+            "${DOCKER_PREFIX[@]}" ${DOCKER_CMD} exec "${NODE_CONTAINER_NAME}" \
+                systemctl --no-pager --full status yuanrong.service sandboxd.service || true
             return 1
         fi
 
@@ -300,6 +373,7 @@ start_traefik_container() {
         --name "${TRAEFIK_CONTAINER_NAME}" \
         --net bridge \
         --restart always \
+        "${TRAEFIK_RUN_ARGS[@]}" \
         -v "${dynamic_config}:/etc/traefik/dynamic.yml:ro" \
         "${TRAEFIK_IMAGE}" \
         --entryPoints.web.address=:80 \
@@ -320,7 +394,7 @@ wait_for_gateway() {
 
     log_info "Waiting for Traefik at ${traefik_ip}"
     for i in $(seq 1 ${retries}); do
-        if curl --noproxy '*' -fkSs "https://${traefik_ip}/healthz" > /dev/null; then
+        if curl --noproxy '*' -fks "https://${traefik_ip}/healthz" > /dev/null 2>&1; then
             log_info "Traefik gateway is ready"
             return 0
         fi
@@ -345,6 +419,7 @@ wait_for_gateway() {
 show_status() {
     local node_ip="$1"
     local traefik_ip="$2"
+    local sdk_address="$3"
 
     echo ""
     log_info "Container status:"
@@ -359,12 +434,14 @@ show_status() {
     echo "  Enter AKernel: ${DOCKER_CMD} exec -it ${NODE_CONTAINER_NAME} bash"
     echo "  AKernel IP:    ${node_ip}"
     echo "  Traefik IP:    ${traefik_ip}"
+    echo "  SDK address:   ${sdk_address}"
     echo "  SDK token:     ${TOKEN_FILE}"
 }
 
 # Main
 check_prerequisites
 cleanup_existing
+configure_local_runtime
 configure_auth
 ensure_image "${IMAGE}"
 ensure_image "${TRAEFIK_IMAGE}"
@@ -385,9 +462,12 @@ if [[ -z "${TRAEFIK_IP}" ]]; then
     log_error "Could not determine the Traefik container IP"
     exit 1
 fi
-wait_for_gateway "${TRAEFIK_IP}"
-show_status "${NODE_IP}" "${TRAEFIK_IP}"
+if [[ -z "${SDK_SERVER_ADDRESS}" ]]; then
+    SDK_SERVER_ADDRESS="${TRAEFIK_IP}"
+fi
+wait_for_gateway "${SDK_SERVER_ADDRESS}"
+show_status "${NODE_IP}" "${TRAEFIK_IP}" "${SDK_SERVER_ADDRESS}"
 
 log_info "AKernel started successfully in standalone mode"
-log_info "Set AKERNEL_SERVER_ADDRESS=${TRAEFIK_IP}"
+log_info "Set AKERNEL_SERVER_ADDRESS=${SDK_SERVER_ADDRESS}"
 log_info "Set AKERNEL_TOKEN=\$(cat ${TOKEN_FILE})"


### PR DESCRIPTION
## Summary

- make the runtime and node image builds architecture-aware for ARM64
- add explicit `PLATFORM=linux/arm64` support to the build workflow
- make standalone startup work on Apple Silicon Docker Desktop
- document the macOS networking, cgroup, and volume requirements

## Why

The existing image and runtime paths assumed x86-64. On Apple Silicon this
forced amd64 emulation, while the standalone mount layout also triggered
Docker Desktop VirtioFS failures and its bridge IP was not reachable directly
from macOS.

## Implementation

- select ARM64 artifacts for gVisor, openYuanRong, and OpenTelemetry
- derive Python runtime and dynamic-linker paths from the target architecture
- use a Docker named volume for standalone runtime state on macOS
- publish the gateway on `127.0.0.1:80/443` on macOS
- provide sandboxd with the host cgroup namespace and writable controllers
- check `yuanrong.service`, `sandboxd.service`, and gateway health explicitly

## Validation

- built the runtime EROFS image and full all-in-one image for `linux/arm64`
- passed the ARM64 sandboxd/runsc privileged e2e
- started the complete standalone stack on Apple Silicon Docker Desktop
- passed basic usage, command stdin, PTY, port forwarding, and reverse tunnel
  SDK examples
- passed 56 SDK unit tests, Ruff, and mypy
- passed ARM64 Dockerfile build checks, shell syntax checks, and
  `git diff --check`

Docker Desktop must expose cgroup v1 controllers. Privilege provides the
required permissions but cannot replace the required cgroup version or kernel
filesystems.
