### PR TITLE
feat: integrate the Kata Containers runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ project guidance.
 AKernel provides cluster-backed remote sandbox environments for agents and
 developer workflows. The current public user-facing surface is the Python
 `akernel-sdk`, including the `akernel_sdk.Sandbox` API and the `ak` CLI.
+The default sandbox runtime is gVisor runsc; callers may select Kata
+Containers when the cluster has a KVM-capable node.
 
 Use AKernel when a task needs an isolated remote environment with command
 execution, file operations, interactive PTYs, port forwarding, or reverse
@@ -37,7 +39,9 @@ build tooling, and examples. Node runtime components such as `sandboxd` and
 `distill-fs` are maintained in their own upstream repositories. The all-in-one
 Docker build copies and compiles their pinned Git submodules in dedicated
 builder stages. It also downloads `runsc` from the official gVisor release
-bucket and verifies its published SHA-512 checksum.
+bucket and verifies its published SHA-512 checksum. The node image packages
+the checksum-pinned Kata Containers 4.0 runtime-rs shim, Dragonball
+configuration, guest kernel, guest images, license, and sandbox logger.
 
 ## Common Commands
 
@@ -107,9 +111,10 @@ AKernel all-in-one image using that runtime image.
 
 Initialize submodules with `git submodule update --init --recursive` before
 building. The all-in-one image builds `sandboxd` and `sbox` from
-`src/sandboxd`, builds `distill_fs` from `src/distill-fs`, and
-downloads the official gVisor `runsc` release pinned by `GVISOR_RELEASE` in
-the image build.
+`src/sandboxd`, builds `sandbox-logger`, builds `distill_fs` from
+`src/distill-fs`, downloads the official gVisor `runsc` release pinned by
+`GVISOR_RELEASE`, and extracts the required amd64 artifacts from the
+checksum-pinned Kata release.
 
 The submodule gitlinks are the single source of truth for the sandboxd and
 distill-fs revisions included in a clean release. `make build` always compiles
@@ -149,6 +154,13 @@ make print-env
 AKernel `v0.1.0` node runtime currently requires Linux x86-64 nodes with
 cgroup v1. Do not deploy it to cgroup v2 nodes or assume bootstrap will detect
 an incompatible host before sandboxd starts.
+
+Kata is present in the default AKernel runtime configuration but is an
+optional node capability. It additionally requires `/dev/kvm` to be usable
+from the node container. A node without KVM remains ready and advertises only
+runsc; a Kata request fails scheduling with a no-resource error when no
+eligible node exists. Do not treat a configured runtime as an advertised
+runtime.
 
 Dragonfly distribution is optional and disabled by default. Enable it during
 profile generation with `make config INSTALL_DRAGONFLY=true`. This installs the
@@ -223,6 +235,13 @@ with Sandbox(cpu=2000, memory=4096) as sb:
     print(result.stdout)
 ```
 
+Select Kata explicitly only when the cluster has an eligible node:
+
+```python
+with Sandbox(runtime="kata", cpu=2000, memory=4096) as sb:
+    print(sb.commands.run("uname -s").stdout)
+```
+
 Required environment:
 
 ```bash
@@ -291,6 +310,17 @@ Run the basic e2e example against a deployed cluster with:
 
 ```bash
 make e2e
+```
+
+The SDK integration and pressure tests are runtime-selectable. Kata tests
+require a KVM-capable standalone or cluster node:
+
+```bash
+AKERNEL_RUN_INTEGRATION=1 \
+AKERNEL_TEST_RUNTIME=kata \
+python -m pytest sdk/python/tests/integration/test_sandbox.py
+
+python sdk/python/benchmarks/sandbox_pressure.py --runtime kata
 ```
 
 ## Maintenance Rules

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ One all-in-one image, multiple deployment targets — deploy in under 10 minutes
 ### Secure Isolation with Extreme Performance
 
 - **40 ms cold start\***: Fork-based launch with lazy loading for near-zero startup latency
-- **Sandbox isolation**: [gVisor](https://github.com/google/gvisor) today, with Kata Containers support\* planned
+- **Sandbox isolation**: [gVisor](https://github.com/google/gvisor) by default, with [Kata Containers](https://github.com/kata-containers/kata-containers) available on KVM-capable nodes
 - **Checkpoint/Restore\***: Save and restore sandbox state for fast recovery
 
 \* Planned for an open-source release and not available in AKernel v0.1.0.
@@ -135,7 +135,7 @@ with Sandbox(cpu=1000, memory=2048) as sandbox:
     print(sandbox.files.read("/tmp/hello.txt"))
 ```
 
-See the complete [basic usage example](./sdk/python/examples/basic_usage.py) and the other [SDK examples](./sdk/python/examples/) for more operations.
+See the complete [basic usage example](./sdk/python/examples/basic_usage.py), the [sandbox runtime example](./sdk/python/examples/sandbox_runtime.py), and the other [SDK examples](./sdk/python/examples/) for more operations.
 
 ## Architecture
 
@@ -144,7 +144,7 @@ See the complete [basic usage example](./sdk/python/examples/basic_usage.py) and
 ### System Components
 
 **Node-Level Infrastructure**
-- **gVisor**: Secure sandboxed container runtime
+- **Sandbox runtimes**: gVisor by default and Kata Containers on KVM-capable nodes
 - **sandboxd**: Sandbox lifecycle daemon with pluggable sandbox runtime integration
 - **distill-fs**: Rust-based FUSE filesystem for lazy rootfs access, chunk caching, and deduplication
 
@@ -158,17 +158,17 @@ See the complete [basic usage example](./sdk/python/examples/basic_usage.py) and
 
 1. **Agent Submits Workload**: Through unified API or SDK
 2. **Scheduler Places Sandbox**: Selects a worker based on requested CPU, memory, and available capacity
-3. **Sandbox Created**: Prepares the rootfs and network and starts gVisor on the selected worker
+3. **Sandbox Created**: Prepares the rootfs and network and starts the selected sandbox runtime on the worker
 4. **Workload Executes**: In secure, isolated sandboxes
 5. **Resources Recycled**: Deletes the sandbox and returns its capacity to the cluster
 
 ## Roadmap
 
-- Fork-based sandbox launch based on gVisor
-- Kata Containers sandbox runtimes
-- Sandbox checkpoint and restore
-- Support for GKE and AWS
-- Cgroup v2 node support
+- [x] Kata Containers runtime on KVM-capable nodes
+- [ ] Fork-based sandbox launch based on gVisor
+- [ ] Sandbox checkpoint and restore
+- [ ] Support for GKE and AWS
+- [ ] Cgroup v2 node support
 
 ## License
 

--- a/builder/node.Dockerfile
+++ b/builder/node.Dockerfile
@@ -9,10 +9,45 @@ ARG DISTILL_FS_BUILD_IMAGE=rust:1.85.0-bookworm
 ARG OPEN_YR_VERSION=0.9.2
 ARG GVISOR_RELEASE=release-20260706.0
 ARG GVISOR_RELEASE_BASE_URL=https://storage.googleapis.com/gvisor/releases
+ARG KATA_BUILD_IMAGE=ubuntu:24.04
+ARG KATA_RELEASE=4.0.0
+ARG KATA_AMD64_SHA256=2c3b9dfeba355582b40aee462b12916c9740654d0230f696adf719d67b063a8c
+ARG KATA_RELEASE_BASE_URL=https://github.com/kata-containers/kata-containers/releases/download
 ARG OTELCOL_CONTRIB_VERSION=0.120.0
 ARG OTELCOL_CONTRIB_URL=https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${OTELCOL_CONTRIB_VERSION}/otelcol-contrib_${OTELCOL_CONTRIB_VERSION}_linux_amd64.tar.gz
 ARG AKERNEL_VERSION=unknown
 ARG AKERNEL_REVISION=unknown
+
+FROM ${KATA_BUILD_IMAGE} AS kata-runtime
+ARG KATA_RELEASE
+ARG KATA_AMD64_SHA256
+ARG KATA_RELEASE_BASE_URL
+ARG TARGETARCH
+RUN set -eux; \
+    test "${TARGETARCH:-amd64}" = "amd64"; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl zstd; \
+    rm -rf /var/lib/apt/lists/*; \
+    archive="/tmp/kata-static-${KATA_RELEASE}-amd64.tar.zst"; \
+    curl -fSL --retry 10 --retry-delay 2 --retry-all-errors \
+      "${KATA_RELEASE_BASE_URL}/${KATA_RELEASE}/kata-static-${KATA_RELEASE}-amd64.tar.zst" \
+      -o "${archive}"; \
+    echo "${KATA_AMD64_SHA256}  ${archive}" | sha256sum -c -; \
+    mkdir -p /kata; \
+    tar --zstd -xf "${archive}" -C /kata \
+      ./opt/kata/runtime-rs/bin/containerd-shim-kata-v2 \
+      ./opt/kata/share/defaults/kata-containers/runtime-rs/configuration-dragonball.toml \
+      ./opt/kata/share/kata-containers/vmlinux-dragonball-experimental.container \
+      ./opt/kata/share/kata-containers/vmlinux-6.18.35-200-dragonball-experimental \
+      ./opt/kata/share/kata-containers/kata-containers.img \
+      ./opt/kata/share/kata-containers/kata-ubuntu-noble.image; \
+    ln -sfn configuration-dragonball.toml \
+      /kata/opt/kata/share/defaults/kata-containers/runtime-rs/configuration.toml; \
+    mkdir -p /kata/opt/kata/share/licenses/kata-containers; \
+    curl -fSL --retry 10 --retry-delay 2 --retry-all-errors \
+      "https://raw.githubusercontent.com/kata-containers/kata-containers/${KATA_RELEASE}/LICENSE" \
+      -o /kata/opt/kata/share/licenses/kata-containers/LICENSE; \
+    rm -f "${archive}"
 
 FROM ${AKERNEL_RUNTIME_IMAGE} AS runtime-image
 
@@ -144,7 +179,10 @@ COPY --from=runtime-image /yr-runtime-rootfs.img ${YR_INSTALLATION_DIR}/yr-runti
 
 COPY --from=sandboxd-builder /src/sandboxd/output/sandboxd /usr/local/bin/sandboxd
 COPY --from=sandboxd-builder /src/sandboxd/output/sbox /usr/local/bin/sbox
+COPY --from=sandboxd-builder /src/sandboxd/output/sandbox-logger /usr/local/bin/sandbox-logger
 COPY --from=distill-fs-builder /src/distill-fs/target/release/distill_fs /usr/local/bin/distill_fs
+COPY --from=kata-runtime /kata/opt/kata /opt/kata
+RUN ln -sf /opt/kata/runtime-rs/bin/containerd-shim-kata-v2 /usr/local/bin/containerd-shim-kata-v2
 
 COPY ./builder/scripts/akernel-entrypoint.sh /usr/local/bin/akernel-entrypoint
 COPY ./builder/scripts/ensure-component-cert.sh /usr/local/bin/ensure-component-cert
@@ -152,7 +190,9 @@ RUN chmod 0755 \
         /usr/local/bin/runsc \
         /usr/local/bin/sandboxd \
         /usr/local/bin/sbox \
+        /usr/local/bin/sandbox-logger \
         /usr/local/bin/distill_fs \
+        /usr/local/bin/containerd-shim-kata-v2 \
         /usr/local/bin/akernel-entrypoint \
         /usr/local/bin/ensure-component-cert
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -30,6 +30,8 @@ support cgroup v2, and bootstrap does not reliably detect an incompatible host
 before sandboxd starts. Verify the node operating system and cgroup mode before
 deployment.
 
+Kata Containers is enabled in the default AKernel runtime configuration and adds one host requirement: `/dev/kvm` must be available to the node container. Nodes without a usable KVM device remain ready and advertise only runsc. If no node advertises Kata, `Sandbox(runtime="kata")` fails scheduling with a no-resource error.
+
 `make config` is interactive by default. It writes:
 
 - `.akernel/default/config.env`

--- a/deploy/akernel/charts/core/values.yaml
+++ b/deploy/akernel/charts/core/values.yaml
@@ -489,6 +489,13 @@ node:
 
         [plugin.runtime.runtime_binary]
         runsc="/usr/local/bin/runsc"
+        kata="/usr/local/bin/containerd-shim-kata-v2"
+
+        [plugin.runtime.kata]
+        config_path="/opt/kata/share/defaults/kata-containers/runtime-rs/configuration-dragonball.toml"
+        kvm_device="/dev/kvm"
+        dan_config_dir="/run/kata-containers/dans"
+        logger_binary="/usr/local/bin/sandbox-logger"
 
         # image-manager config. root holds image-manager runtime state
         # (daemons/, mount_records.db) and is wiped on pod change; input

--- a/deploy/standalone/README.md
+++ b/deploy/standalone/README.md
@@ -11,6 +11,8 @@ Keeping the gateway in a separate network namespace allows sandboxd's normal
 `PREROUTING` port-forwarding rules to handle traffic without standalone-only
 NAT synchronization logic.
 
+The default runtime is gVisor `runsc`. `Sandbox(runtime="kata")` additionally requires `/dev/kvm` and hardware or nested virtualization on the Docker host. Nodes without KVM remain usable with runsc and do not advertise Kata to the scheduler.
+
 ## Directory Structure
 
 ```

--- a/deploy/standalone/config/sandboxd_config.toml
+++ b/deploy/standalone/config/sandboxd_config.toml
@@ -38,6 +38,13 @@ runsc="/home/akernel/images/config.json"
 
 [plugin.runtime.runtime_binary]
 runsc="/usr/local/bin/runsc"
+kata="/usr/local/bin/containerd-shim-kata-v2"
+
+[plugin.runtime.kata]
+config_path="/opt/kata/share/defaults/kata-containers/runtime-rs/configuration-dragonball.toml"
+kvm_device="/dev/kvm"
+dan_config_dir="/run/kata-containers/dans"
+logger_binary="/usr/local/bin/sandbox-logger"
 
 # image-manager config. root holds image-manager runtime state and is wiped
 # on pod change; input configs live under /home/akernel/sandboxd/config/ so the

--- a/deploy/standalone/start.sh
+++ b/deploy/standalone/start.sh
@@ -75,6 +75,12 @@ check_prerequisites() {
 
     log_info "${DOCKER_CMD} is available"
 
+    if [[ ! -c /dev/kvm ]]; then
+        log_warn "/dev/kvm is unavailable; standalone will support runsc but will not advertise the Kata runtime"
+    elif [[ ! -r /dev/kvm || ! -w /dev/kvm ]]; then
+        log_warn "/dev/kvm is not accessible to the current user; verify that the privileged node container can access it before using Kata"
+    fi
+
     if ! command -v curl &> /dev/null; then
         log_error "curl is required to verify the standalone endpoint"
         exit 1

--- a/deploy/terraform/aliyun/values-akernel.yaml.tmpl
+++ b/deploy/terraform/aliyun/values-akernel.yaml.tmpl
@@ -200,6 +200,13 @@ node:
 
         [plugin.runtime.runtime_binary]
         runsc="/usr/local/bin/runsc"
+        kata="/usr/local/bin/containerd-shim-kata-v2"
+
+        [plugin.runtime.kata]
+        config_path="/opt/kata/share/defaults/kata-containers/runtime-rs/configuration-dragonball.toml"
+        kvm_device="/dev/kvm"
+        dan_config_dir="/run/kata-containers/dans"
+        logger_binary="/usr/local/bin/sandbox-logger"
 
         # image-manager config. root holds image-manager runtime state
         # (daemons/, mount_records.db) and is wiped on pod change; input

--- a/deploy/terraform/huaweicloud/values-akernel.yaml.tmpl
+++ b/deploy/terraform/huaweicloud/values-akernel.yaml.tmpl
@@ -158,6 +158,13 @@ node:
 
         [plugin.runtime.runtime_binary]
         runsc="/usr/local/bin/runsc"
+        kata="/usr/local/bin/containerd-shim-kata-v2"
+
+        [plugin.runtime.kata]
+        config_path="/opt/kata/share/defaults/kata-containers/runtime-rs/configuration-dragonball.toml"
+        kvm_device="/dev/kvm"
+        dan_config_dir="/run/kata-containers/dans"
+        logger_binary="/usr/local/bin/sandbox-logger"
 
         # image-manager config. root holds image-manager runtime state
         # (daemons/, mount_records.db) and is wiped on pod change; input

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -82,12 +82,21 @@ Sandbox(
 )
 ```
 
-`cpu` is measured in millicores and `memory` in MiB. A zero CPU or memory
-limit means the limit follows the corresponding request. A positive limit
-must not be smaller than its request.
+`cpu` is measured in millicores and `memory` in MiB. A zero CPU or memory limit means the limit follows the corresponding request. A positive limit must not be smaller than its request.
 
-AKernel 0.1.0 supports the gVisor `runsc` runtime. The independent `runtime`
-parameter leaves room for future Kata support without changing the rootfs API.
+## Sandbox runtimes
+
+AKernel uses the gVisor `runsc` runtime when `runtime` is omitted. Callers may also select `runsc` explicitly or request Kata Containers:
+
+```python
+default_sandbox = Sandbox()
+runsc_sandbox = Sandbox(runtime="runsc")
+kata_sandbox = Sandbox(runtime="kata")
+```
+
+Kata requires at least one cluster node whose sandboxd instance successfully initialized the Kata runtime with a usable `/dev/kvm` device. Nodes without KVM remain available for runsc workloads and do not advertise Kata; when no eligible Kata node exists, the scheduler returns a no-resource error.
+
+See [`examples/sandbox_runtime.py`](./examples/sandbox_runtime.py) for a runnable example.
 
 ## Commands
 

--- a/sdk/python/akernel_sdk/_openyuanrong.py
+++ b/sdk/python/akernel_sdk/_openyuanrong.py
@@ -35,6 +35,7 @@ from .types import HttpReverseTunnel, Mount, NodeInfo, S3Config
 logger = logging.getLogger(__name__)
 
 _NAMESPACE = "akernel"
+_DEFAULT_LOCAL_ROOTFS = "/home/yuanrong/yr-runtime-rootfs.img"
 _initialized = False
 _init_lock = threading.Lock()
 
@@ -104,7 +105,16 @@ def _rootfs_json(
                 "runtime": runtime,
                 "type": "s3",
                 "readonly": False,
-                "s3_config": rootfs.to_dict(),
+                "storageInfo": rootfs.to_dict(),
+            }
+        )
+    if runtime != "runsc":
+        return json.dumps(
+            {
+                "runtime": runtime,
+                "type": "local",
+                "readonly": False,
+                "path": _DEFAULT_LOCAL_ROOTFS,
             }
         )
     return None

--- a/sdk/python/akernel_sdk/sandbox.py
+++ b/sdk/python/akernel_sdk/sandbox.py
@@ -29,7 +29,7 @@ from .filesystem import Filesystem
 from .pty import Pty
 from .types import HttpReverseTunnel, Mount, S3Config, SandboxInfo
 
-_SUPPORTED_RUNTIMES = ("runsc",)
+_SUPPORTED_RUNTIMES = ("runsc", "kata")
 _traefik_internal_ip_cache: str | None = None
 
 
@@ -91,8 +91,8 @@ def _get_traefik_internal_ip(gateway: Endpoint) -> tuple[str, int]:
 class Sandbox:
     """A remote AKernel sandbox.
 
-    The public API is backend-neutral. AKernel 0.1.0 currently implements it
-    with the openYuanrong backend adapter and the gVisor ``runsc`` runtime.
+    The public API is backend-neutral. AKernel supports the gVisor ``runsc``
+    runtime and Kata Containers on KVM-capable nodes.
     """
 
     def __init__(
@@ -120,7 +120,7 @@ class Sandbox:
         Args:
             image: OCI image used as the sandbox root filesystem.
             rootfs: S3-compatible EROFS root filesystem configuration.
-            runtime: Sandbox runtime name. AKernel 0.1.0 supports ``runsc``.
+            runtime: Sandbox runtime name: ``runsc`` or ``kata``.
             cpu: Requested CPU in millicores.
             memory: Requested memory in MiB.
             cpu_limit: CPU limit in millicores, or zero to follow ``cpu``.

--- a/sdk/python/benchmarks/sandbox_pressure.py
+++ b/sdk/python/benchmarks/sandbox_pressure.py
@@ -59,6 +59,7 @@ from akernel_sdk import HttpReverseTunnel, Sandbox
 
 # Empty => don't configure an image; the cluster default image is used.
 DEFAULT_IMAGE = os.environ.get("AKERNEL_PRESSURE_IMAGE", "")
+DEFAULT_RUNTIME = os.environ.get("AKERNEL_PRESSURE_RUNTIME", "runsc")
 
 # Keep the default workload independent of optional image tools and external
 # network availability. Callers can use --cmd for application-level pressure.
@@ -85,6 +86,7 @@ def _safe_kill(sb):
 
 def _build_sandbox_kwargs(
     image,
+    runtime,
     cpu,
     memory,
     cpu_limit,
@@ -95,6 +97,7 @@ def _build_sandbox_kwargs(
     listen_port,
 ):
     kwargs = {
+        "runtime": runtime,
         "cpu": cpu,
         "memory": memory,
         "cpu_limit": cpu_limit,
@@ -160,6 +163,7 @@ def worker_process(
     threads_per_proc,
     duration,
     image,
+    runtime,
     cpu,
     memory,
     cpu_limit,
@@ -183,6 +187,7 @@ def worker_process(
     }
     sb_kwargs = _build_sandbox_kwargs(
         image,
+        runtime,
         cpu,
         memory,
         cpu_limit,
@@ -258,6 +263,7 @@ def main(args):
         f"   threads/proc   : {args.threads}\n"
         f"   total parallel : {args.processes * args.threads}\n"
         f"   duration       : {args.duration}s\n"
+        f"   runtime        : {args.runtime}\n"
         f"   image (rootfs) : {args.image or '<cluster default>'}\n"
         f"   cpu req/limit  : {args.cpu}m / {args.cpu_limit}m\n"
         f"   mem req/limit  : {args.memory}MiB / {args.mem_limit}MiB\n"
@@ -279,6 +285,7 @@ def main(args):
                 args.threads,
                 args.duration,
                 args.image,
+                args.runtime,
                 args.cpu,
                 args.memory,
                 args.cpu_limit,
@@ -377,6 +384,12 @@ if __name__ == "__main__":
         help="custom rootfs image (empty = use cluster default image)",
     )
     parser.add_argument(
+        "--runtime",
+        choices=("runsc", "kata"),
+        default=DEFAULT_RUNTIME,
+        help="sandbox runtime (default: AKERNEL_PRESSURE_RUNTIME or runsc)",
+    )
+    parser.add_argument(
         "--cpu", type=int, default=100, help="cpu request, milli-cores (100=0.1c)"
     )
     parser.add_argument(
@@ -413,7 +426,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "--cmd",
         default=DEFAULT_CMD,
-        help=f"workload command (use {TUNNEL_URL_PLACEHOLDER} for tunnel-url substitution)",
+        help=(
+            f"workload command (use {TUNNEL_URL_PLACEHOLDER} for "
+            "tunnel-url substitution)"
+        ),
     )
     parser.add_argument("--cmd-timeout", type=int, default=20)
     args = parser.parse_args()

--- a/sdk/python/examples/sandbox_runtime.py
+++ b/sdk/python/examples/sandbox_runtime.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 Ant Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Select a sandbox runtime.
+
+The Kata case requires at least one cluster node that advertises Kata support.
+Otherwise, the scheduler returns a no-resource error.
+"""
+
+from akernel_sdk import Sandbox
+
+
+def run(runtime: str | None) -> None:
+    sandbox = (
+        Sandbox(cpu=1000, memory=2048)
+        if runtime is None
+        else Sandbox(runtime=runtime, cpu=1000, memory=2048)
+    )
+    with sandbox:
+        result = sandbox.commands.run("uname -s")
+        assert result.exit_code == 0, result.stderr
+        print(f"{runtime or 'default'}: {sandbox.id} ({result.stdout})")
+
+
+def main() -> None:
+    run(None)
+    run("runsc")
+    run("kata")
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/python/tests/integration/test_sandbox.py
+++ b/sdk/python/tests/integration/test_sandbox.py
@@ -23,6 +23,7 @@ _ENABLED = (
     and bool(os.environ.get("AKERNEL_SERVER_ADDRESS"))
     and bool(os.environ.get("AKERNEL_TOKEN"))
 )
+_RUNTIME = os.environ.get("AKERNEL_TEST_RUNTIME", "runsc")
 
 
 @unittest.skipUnless(
@@ -32,7 +33,7 @@ _ENABLED = (
 class SandboxIntegrationTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.sandbox = Sandbox(cpu=1000, memory=2048)
+        cls.sandbox = Sandbox(cpu=1000, memory=2048, runtime=_RUNTIME)
 
     @classmethod
     def tearDownClass(cls):

--- a/sdk/python/tests/unit/test_openyuanrong.py
+++ b/sdk/python/tests/unit/test_openyuanrong.py
@@ -63,7 +63,19 @@ class OpenYuanRongAdapterTest(unittest.TestCase):
                 "runtime": "runsc",
                 "type": "s3",
                 "readonly": False,
-                "s3_config": config.to_dict(),
+                "storageInfo": config.to_dict(),
+            },
+        )
+
+    def test_kata_uses_the_default_local_rootfs(self):
+        options = self.build_options(runtime="kata")
+        self.assertEqual(
+            json.loads(options.custom_extensions["rootfs"]),
+            {
+                "runtime": "kata",
+                "type": "local",
+                "readonly": False,
+                "path": "/home/yuanrong/yr-runtime-rootfs.img",
             },
         )
 

--- a/sdk/python/tests/unit/test_sandbox.py
+++ b/sdk/python/tests/unit/test_sandbox.py
@@ -83,9 +83,11 @@ class SandboxTest(unittest.TestCase):
                 rootfs=S3Config("https://s3.example.com", "rootfs", "rootfs.img"),
             )
 
-    def test_only_runsc_is_supported(self):
+    def test_supported_runtimes(self):
+        Sandbox(runtime="kata")
+
         with self.assertRaisesRegex(ValueError, "unsupported runtime"):
-            Sandbox(runtime="kata")
+            Sandbox(runtime="unknown")
 
     def test_port_forwardings_are_integer_ports(self):
         with self.assertRaisesRegex(TypeError, "integer"):


### PR DESCRIPTION

## What does this PR do?

This PR adds Kata Containers 4.0 as an optional AKernel sandbox runtime while keeping gVisor runsc as the default.

The all-in-one image packages the runtime-rs shim, Dragonball configuration and guest artifacts, and sandbox logger. Standalone, Helm, Alibaba Cloud, and Huawei Cloud deployments declare Kata as an optional runtime.

During node initialization, sandboxd validates the Kata components and `/dev/kvm`. A node without usable KVM remains ready and advertises only runsc. The Python SDK can request Kata with `Sandbox(runtime="kata")` and supports the default local rootfs, OCI images, and S3-backed EROFS images.

## Testing

Verified the all-in-one image build, Python SDK unit tests, runsc and Kata integration tests and examples, concurrent pressure tests, and post-test resource cleanup.
