### PR TITLE
feat(runtime): add Python 3.14 and Rust RRT support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,8 +105,8 @@ The build creates only the selected image reference; it does not add a second
 `akernel-all-in-one` alias. `make push` pushes that selected reference directly.
 
 The build helper performs two Docker builds. `builder/runtime.Dockerfile`
-assembles the Python 3.10 through 3.14 runtimes and creates
-`yr-runtime-rootfs.img`.
+assembles the Python 3.10 through 3.14 runtimes, installs the pinned
+openYuanRong RRT binary, and creates `yr-runtime-rootfs.img`.
 `builder/node.Dockerfile` then compiles the node components and produces the
 AKernel all-in-one image using that runtime image.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,8 @@ The build creates only the selected image reference; it does not add a second
 `akernel-all-in-one` alias. `make push` pushes that selected reference directly.
 
 The build helper performs two Docker builds. `builder/runtime.Dockerfile`
-assembles the Python runtimes and creates `yr-runtime-rootfs.img`.
+assembles the Python 3.10 through 3.14 runtimes and creates
+`yr-runtime-rootfs.img`.
 `builder/node.Dockerfile` then compiles the node components and produces the
 AKernel all-in-one image using that runtime image.
 

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,8 @@ deploy-script-check:
 	done < <(git ls-files -z -- 'deploy/**/*.sh.tftpl'); \
 	git ls-files -z -- 'deploy/**/*.py' | \
 		xargs -0 -r python3 -c \
-		'import pathlib, sys; [compile(pathlib.Path(path).read_bytes(), path, "exec") for path in sys.argv[1:]]'
+		'import pathlib, sys; [compile(pathlib.Path(path).read_bytes(), path, "exec") for path in sys.argv[1:]]'; \
+	python3 -m unittest discover -s deploy/tests -p 'test_*.py' -v
 
 .PHONY: destroy
 destroy:

--- a/builder/config/yr_services.yaml
+++ b/builder/config/yr_services.yaml
@@ -50,3 +50,15 @@
         type: erofs
         root: "/home/yuanrong/yr-runtime-rootfs.img"
         entrypoint: "/__yuanrong/usr/bin/tini-static -- sh /__yuanrong/home/entryfile.sh"
+    py314:
+      runtime: python3.14
+      rootfs:
+        runtime: runsc
+        type: local
+        path: /home/yuanrong/yr-runtime-rootfs.img
+        readonly: false
+        mountpoint: /var/task/code
+      bootstrap:
+        type: erofs
+        root: "/home/yuanrong/yr-runtime-rootfs.img"
+        entrypoint: "/__yuanrong/usr/bin/tini-static -- sh /__yuanrong/home/entryfile.sh"

--- a/builder/config/yr_services.yaml
+++ b/builder/config/yr_services.yaml
@@ -2,6 +2,18 @@
   kind: yrlib # Function type. Required. Process deployment supports yrlib only.
   description: this is the default service # Optional service description.
   functions: # Function definitions. Required.
+    rrt:
+      runtime: rust
+      rootfs:
+        runtime: runsc
+        type: local
+        path: /home/yuanrong/yr-runtime-rootfs.img
+        readonly: false
+        mountpoint: /var/task/code
+      bootstrap:
+        type: erofs
+        root: "/home/yuanrong/yr-runtime-rootfs.img"
+        entrypoint: "/__yuanrong/usr/bin/tini-static -- /__yuanrong/usr/local/bin/rrt-runtime"
     py311:
       runtime: python3.11
       rootfs:

--- a/builder/runtime.Dockerfile
+++ b/builder/runtime.Dockerfile
@@ -3,11 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG AKERNEL_RUNTIME_BASE_IMAGE=ubuntu:24.04
-ARG UV_VERSION=0.7.13
+ARG UV_VERSION=0.11.32
 ARG PYTHON_310_VERSION=3.10.18
 ARG PYTHON_311_VERSION=3.11.13
 ARG PYTHON_312_VERSION=3.12.11
 ARG PYTHON_313_VERSION=3.13.5
+ARG PYTHON_314_VERSION=3.14.6
 
 FROM ${AKERNEL_RUNTIME_BASE_IMAGE} AS python-runtime-base
 
@@ -16,6 +17,7 @@ ARG PYTHON_310_VERSION
 ARG PYTHON_311_VERSION
 ARG PYTHON_312_VERSION
 ARG PYTHON_313_VERSION
+ARG PYTHON_314_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive \
     UV_CACHE_DIR=/tmp/uv-cache \
@@ -53,7 +55,8 @@ RUN uv python install \
         "${PYTHON_310_VERSION}" \
         "${PYTHON_311_VERSION}" \
         "${PYTHON_312_VERSION}" \
-        "${PYTHON_313_VERSION}"; \
+        "${PYTHON_313_VERSION}" \
+        "${PYTHON_314_VERSION}"; \
     rm -rf "${UV_CACHE_DIR}"
 
 RUN set -eux; \
@@ -61,7 +64,8 @@ RUN set -eux; \
         "3.10:${PYTHON_310_VERSION}" \
         "3.11:${PYTHON_311_VERSION}" \
         "3.12:${PYTHON_312_VERSION}" \
-        "3.13:${PYTHON_313_VERSION}"; do \
+        "3.13:${PYTHON_313_VERSION}" \
+        "3.14:${PYTHON_314_VERSION}"; do \
         py="${spec%%:*}"; \
         version="${spec#*:}"; \
         uv venv "/opt/venv-py${py}" --python "${version}" --seed; \
@@ -82,6 +86,7 @@ ARG PYTHON_310_VERSION
 ARG PYTHON_311_VERSION
 ARG PYTHON_312_VERSION
 ARG PYTHON_313_VERSION
+ARG PYTHON_314_VERSION
 
 RUN mkdir -p /var/task/code /__yuanrong && \
     ln -sfn /home /__yuanrong/home && \
@@ -180,10 +185,31 @@ RUN set -eux; \
         "/opt/python${py}"; \
     rm -rf "${UV_CACHE_DIR:-/tmp/uv-cache}"
 
+RUN set -eux; \
+    py="3.14"; version="${PYTHON_314_VERSION}"; \
+    attempt=1; \
+    while true; do \
+        uv pip install \
+            --no-cache-dir \
+            --index-url "${PIP_INDEX_URL}" \
+            --python "/opt/venv-py${py}/bin/python" \
+            "fastapi==${FASTAPI_VERSION}" \
+            "pydantic==${PYDANTIC_VERSION}" \
+            "uvicorn==${UVICORN_VERSION}" \
+            "openyuanrong_sdk==${OPEN_YR_VERSION}" && break; \
+        if [ "${attempt}" -ge 3 ]; then exit 1; fi; \
+        sleep $((attempt * 5)); \
+        attempt=$((attempt + 1)); \
+    done; \
+    ln -sfn \
+        "uv-python/cpython-${version}-linux-x86_64-gnu/bin/python${py}" \
+        "/opt/python${py}"; \
+    rm -rf "${UV_CACHE_DIR:-/tmp/uv-cache}"
+
 COPY ./builder/scripts/entryfile.sh /home/entryfile.sh
 RUN set -eux; \
     chmod 0755 /home/entryfile.sh; \
-    for py in 3.10 3.11 3.12 3.13; do \
+    for py in 3.10 3.11 3.12 3.13 3.14; do \
         "/opt/venv-py${py}/bin/python" -m compileall -q \
             "/opt/venv-py${py}/lib/python${py}/site-packages"; \
     done

--- a/builder/runtime.Dockerfile
+++ b/builder/runtime.Dockerfile
@@ -206,6 +206,17 @@ RUN set -eux; \
         "/opt/python${py}"; \
     rm -rf "${UV_CACHE_DIR:-/tmp/uv-cache}"
 
+ARG RRT_RUNTIME_BASE_URL=https://openyuanrong.obs.cn-southwest-2.myhuaweicloud.com/release
+ARG RRT_RUNTIME_SHA256=2458c958ffd82ee781817e3fa78b089f741de2367c5d23b9aa2ef00b566585d0
+
+RUN set -eux; \
+    rrt_runtime_url="${RRT_RUNTIME_BASE_URL}/${OPEN_YR_VERSION}/linux/amd64/rrt-runtime-amd64"; \
+    curl -fSL --retry 5 --retry-delay 2 --retry-all-errors \
+        -o /tmp/rrt-runtime "${rrt_runtime_url}"; \
+    echo "${RRT_RUNTIME_SHA256}  /tmp/rrt-runtime" | sha256sum -c -; \
+    install -m 0755 /tmp/rrt-runtime /usr/local/bin/rrt-runtime; \
+    rm -f /tmp/rrt-runtime
+
 COPY ./builder/scripts/entryfile.sh /home/entryfile.sh
 RUN set -eux; \
     chmod 0755 /home/entryfile.sh; \

--- a/builder/scripts/entryfile.sh
+++ b/builder/scripts/entryfile.sh
@@ -21,8 +21,11 @@ case "$RUNTIME_ENV" in
     python3.13)
         PY_VERSION=3.13
         ;;
+    python3.14)
+        PY_VERSION=3.14
+        ;;
     *)
-        echo "unsupported YR_LANGUAGE=${RUNTIME_ENV}; supported runtimes: python3.10, python3.11, python3.12, python3.13" >&2
+        echo "unsupported YR_LANGUAGE=${RUNTIME_ENV}; supported runtimes: python3.10, python3.11, python3.12, python3.13, python3.14" >&2
         exit 127
         ;;
 esac

--- a/deploy/akernel/charts/core/templates/traefik/configmap.yaml
+++ b/deploy/akernel/charts/core/templates/traefik/configmap.yaml
@@ -81,7 +81,14 @@ data:
         frontend-terminal:
           entryPoints:
             - websecure
-          rule: "PathPrefix(`/terminal`) || PathPrefix(`/api/instances`) || PathPrefix(`/api/jobs`) || PathPrefix(`/functions`) || PathPrefix(`/api-docs`) || PathPrefix(`/admin/v1/functions`) || PathPrefix(`/serverless/v1/functions`) || PathPrefix(`/serverless/v1/stream`) || PathPrefix(`/serverless/v1/componentshealth`) || PathPrefix(`/serverless/v1/posix`) || PathPrefix(`/serverless/v2`) || PathPrefix(`/frontend/v1/instance`) || PathPrefix(`/datasystem/v1`) || PathPrefix(`/app/v1`) || PathPrefix(`/client/v1/lease`) || PathPrefix(`/invocations`) || PathPrefix(`/global-scheduler`) || Path(`/healthz`)"
+          rule: "PathPrefix(`/terminal`) || PathPrefix(`/api/instances`) || PathPrefix(`/api/jobs`) || PathPrefix(`/api/sandbox`) || PathPrefix(`/functions`) || PathPrefix(`/api-docs`) || PathPrefix(`/admin/v1/functions`) || PathPrefix(`/serverless/v1/functions`) || PathPrefix(`/serverless/v1/stream`) || PathPrefix(`/serverless/v1/componentshealth`) || PathPrefix(`/serverless/v1/posix`) || PathPrefix(`/serverless/v2`) || PathPrefix(`/frontend/v1/instance`) || PathPrefix(`/datasystem/v1`) || PathPrefix(`/app/v1`) || PathPrefix(`/client/v1/lease`) || PathPrefix(`/invocations`) || PathPrefix(`/global-scheduler`) || Path(`/healthz`)"
+          service: {{ if .Values.frontend.enabled }}akernel-frontend{{ else }}akernel-master{{ end }}
+          tls: {}
+        direct-router:
+          entryPoints:
+            - websecure
+          rule: "PathPrefix(`/direct/`) || Path(`/direct`)"
+          priority: 100
           service: {{ if .Values.frontend.enabled }}akernel-frontend{{ else }}akernel-master{{ end }}
           tls: {}
         {{- if .Values.traefik.grafana.enabled }}

--- a/deploy/standalone/start.sh
+++ b/deploy/standalone/start.sh
@@ -279,7 +279,14 @@ http:
     akernel-frontend:
       entryPoints:
         - websecure
-      rule: "PathPrefix(\`/terminal\`) || PathPrefix(\`/api/instances\`) || PathPrefix(\`/api/jobs\`) || PathPrefix(\`/functions\`) || PathPrefix(\`/api-docs\`) || PathPrefix(\`/admin/v1/functions\`) || PathPrefix(\`/serverless/v1/functions\`) || PathPrefix(\`/serverless/v1/stream\`) || PathPrefix(\`/serverless/v1/componentshealth\`) || PathPrefix(\`/serverless/v1/posix\`) || PathPrefix(\`/serverless/v2\`) || PathPrefix(\`/frontend/v1/instance\`) || PathPrefix(\`/datasystem/v1\`) || PathPrefix(\`/app/v1\`) || PathPrefix(\`/client/v1/lease\`) || PathPrefix(\`/invocations\`) || PathPrefix(\`/global-scheduler\`) || Path(\`/healthz\`)"
+      rule: "PathPrefix(\`/terminal\`) || PathPrefix(\`/api/instances\`) || PathPrefix(\`/api/jobs\`) || PathPrefix(\`/api/sandbox\`) || PathPrefix(\`/functions\`) || PathPrefix(\`/api-docs\`) || PathPrefix(\`/admin/v1/functions\`) || PathPrefix(\`/serverless/v1/functions\`) || PathPrefix(\`/serverless/v1/stream\`) || PathPrefix(\`/serverless/v1/componentshealth\`) || PathPrefix(\`/serverless/v1/posix\`) || PathPrefix(\`/serverless/v2\`) || PathPrefix(\`/frontend/v1/instance\`) || PathPrefix(\`/datasystem/v1\`) || PathPrefix(\`/app/v1\`) || PathPrefix(\`/client/v1/lease\`) || PathPrefix(\`/invocations\`) || PathPrefix(\`/global-scheduler\`) || Path(\`/healthz\`)"
+      service: akernel-frontend
+      tls: {}
+    direct-router:
+      entryPoints:
+        - websecure
+      rule: "PathPrefix(\`/direct/\`) || Path(\`/direct\`)"
+      priority: 100
       service: akernel-frontend
       tls: {}
 

--- a/deploy/tests/test_traefik_routes.py
+++ b/deploy/tests/test_traefik_routes.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 Ant Group Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Keep Helm and standalone sandbox routes aligned."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HELM_CONFIG = (
+    ROOT
+    / "deploy/akernel/charts/core/templates/traefik/configmap.yaml"
+).read_text(encoding="utf-8")
+STANDALONE_CONFIG = (
+    ROOT / "deploy/standalone/start.sh"
+).read_text(encoding="utf-8")
+
+
+class TraefikSandboxRoutesTest(unittest.TestCase):
+    def test_sandbox_control_api_routes_to_frontend(self) -> None:
+        self.assertIn("PathPrefix(`/api/sandbox`)", HELM_CONFIG)
+        self.assertIn(r"PathPrefix(\`/api/sandbox\`)", STANDALONE_CONFIG)
+
+    def test_direct_api_uses_a_high_priority_frontend_router(self) -> None:
+        self.assertIn(
+            'rule: "PathPrefix(`/direct/`) || Path(`/direct`)"',
+            HELM_CONFIG,
+        )
+        self.assertIn(
+            r'rule: "PathPrefix(\`/direct/\`) || Path(\`/direct\`)"',
+            STANDALONE_CONFIG,
+        )
+        self.assertIn("priority: 100", HELM_CONFIG)
+        self.assertIn("priority: 100", STANDALONE_CONFIG)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Distributed Computing",
 ]


### PR DESCRIPTION
## Summary

- bundle CPython 3.14.6 alongside Python 3.10–3.13
- register `py314` and update the runtime selector
- upgrade uv because the previous pin cannot resolve CPython 3.14.6
- install the checksum-pinned openYuanRong 0.9.2 RRT binary
- register the RRT-backed `rust` service
- use `OPEN_YR_VERSION` for both the Python SDK and RRT download URL
- route `/api/sandbox` and the RRT `/direct` fast path through Traefik
- keep Helm and standalone Traefik sandbox routes covered by regression tests

## Why uv changes

The previous `uv==0.7.13` pin fails with:

```text
error: No download found for request: cpython-3.14.6-linux-x86_64-gnu
```

`uv==0.11.32` resolves and installs the pinned CPython 3.14.6 runtime. The upgrade is therefore required for the new managed interpreter rather than being an unrelated dependency refresh.

## Version alignment

The RRT URL is built as:

```text
${RRT_RUNTIME_BASE_URL}/${OPEN_YR_VERSION}/linux/amd64/rrt-runtime-amd64
```

With `OPEN_YR_VERSION=0.9.2`, both `openyuanrong_sdk` and the RRT binary use release 0.9.2. The artifact was downloaded and its pinned SHA-256 was verified.

## Traefik routing

Both Helm and standalone deployments now register:

- `PathPrefix(`/api/sandbox`)` on the frontend control router
- a priority-100 router for `PathPrefix(`/direct/`) || Path(`/direct`)`

The `/direct` router targets the frontend rather than a dynamic sandbox service, allowing the frontend to resolve the sandbox and proxy the RRT fast path safely.

## Validation

- `make sdk-check`: 57 tests passed; Ruff and mypy passed
- `make deploy-script-check`, including two Traefik route regression tests
- `helm lint` with Traefik enabled
- rendered and parsed Helm routes with frontend enabled and disabled
- generated and parsed the standalone Traefik dynamic YAML
- reproduced the uv 0.7.13 CPython 3.14.6 resolution failure
- built the combined `runtime-rootfs` target using RRT 0.9.2
- verified the RRT SHA-256 and executable bit
- imported runtime dependencies under Python 3.10–3.14
- validated both `rrt` and `py314` service definitions
- built the complete EROFS runtime image; build-time `fsck.erofs` passed
- verified remote CPython 3.14.6 at `/opt/python3.14` on the validation cluster
- ran the maintained Sandbox SDK E2E from a Python 3.14.6 client
- restored the validation cluster and confirmed all core workloads Ready

All commits use conventional subjects, prose bodies, DCO sign-offs, and commit-message lines no longer than 72 characters.