### PR TITLE
feat(sdk): support multiple openYuanRong backends

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,6 +24,7 @@ deploy/standalone/output/
 # dedicated Docker stages.
 src/distill-fs/target/
 src/sandboxd/output/
+src/yuanrong/
 
 # Python caches and package outputs.
 **/__pycache__/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,9 @@ jobs:
       - name: Install SDK dependencies
         run: |
           unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY no_proxy NO_PROXY
-          python -m pip install -e ./sdk/python
+          python -m pip install \
+            --index-url https://pypi.org/simple \
+            -e './sdk/python[all]'
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -69,8 +69,12 @@ jobs:
       - name: Install build dependencies
         run: |
           unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY no_proxy NO_PROXY
-          python -m pip install --upgrade pip
-          python -m pip install -e './sdk/python[dev]' 'twine>=5,<7'
+          python -m pip install \
+            --index-url https://pypi.org/simple \
+            --upgrade pip
+          python -m pip install \
+            --index-url https://pypi.org/simple \
+            -e './sdk/python[dev]' 'twine>=5,<7'
 
       - name: Check SDK
         run: |
@@ -91,7 +95,8 @@ jobs:
           unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY no_proxy NO_PROXY
           python -m venv /tmp/akernel-wheel-test
           /tmp/akernel-wheel-test/bin/python -m pip install \
-            --no-deps sdk/python/dist/*.whl
+            --index-url https://pypi.org/simple \
+            sdk/python/dist/*.whl
           /tmp/akernel-wheel-test/bin/python - <<'PY'
           from importlib.metadata import distribution, version
 
@@ -103,6 +108,7 @@ jobs:
               for entry in distribution("akernel-sdk").entry_points
           )
           assert akernel_sdk.__name__ == "akernel_sdk"
+          assert akernel_sdk.get_backend() == "openyuanrong-sandbox"
           PY
 
       - name: Upload distributions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,9 +269,22 @@ contain only the project-level entry points and representative examples:
 Install the SDK development tools and run the complete local quality gate with:
 
 ```bash
+python3 -m pip install \
+  --index-url https://pypi.org/simple \
+  "openyuanrong-sandbox==0.9.3"
 python3 -m pip install -e './sdk/python[dev]'
 make sdk-check
 ```
+
+The Python SDK installs `openyuanrong-sandbox` as its default execution
+backend. The actor-based `openyuanrong-sdk` backend is available through the
+`openyuanrong-sdk` extra. Installing that extra leaves both distributions
+present, so `openyuanrong-sandbox` remains the automatic default unless
+`AKERNEL_BACKEND=openyuanrong-sdk` is set before import. Backend selection
+happens once during import and backend modules are loaded lazily on first use.
+Keep public `Sandbox`, `Commands`, `Filesystem`, and value types independent
+of both native packages; all native conversions belong under
+`akernel_sdk._backends`.
 
 When changing a public SDK method, update its type annotations and docstring,
 add or update unit coverage, and keep the SDK README and maintained examples in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,8 @@ The build creates only the selected image reference; it does not add a second
 `akernel-all-in-one` alias. `make push` pushes that selected reference directly.
 
 The build helper performs two Docker builds. `builder/runtime.Dockerfile`
-assembles the Python runtimes and creates `yr-runtime-rootfs.img`.
+assembles the Python 3.10 through 3.14 runtimes, installs the pinned
+openYuanRong RRT binary, and creates `yr-runtime-rootfs.img`.
 `builder/node.Dockerfile` then compiles the node components and produces the
 AKernel all-in-one image using that runtime image.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,6 +286,11 @@ Keep public `Sandbox`, `Commands`, `Filesystem`, and value types independent
 of both native packages; all native conversions belong under
 `akernel_sdk._backends`.
 
+The public XPU request format is `type:model:count`. The sandbox backend
+passes it to `yr_sandbox.Sandbox`, while the actor backend converts it to an
+openYuanRong custom resource such as `GPU/NVIDIA-A10/count`; an empty model
+uses the `.+` scheduler wildcard.
+
 When changing a public SDK method, update its type annotations and docstring,
 add or update unit coverage, and keep the SDK README and maintained examples in
 sync. Benchmark programs under `sdk/python/benchmarks/` are manual tools and

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,8 @@ deploy-script-check:
 	done < <(git ls-files -z -- 'deploy/**/*.sh.tftpl'); \
 	git ls-files -z -- 'deploy/**/*.py' | \
 		xargs -0 -r python3 -c \
-		'import pathlib, sys; [compile(pathlib.Path(path).read_bytes(), path, "exec") for path in sys.argv[1:]]'
+		'import pathlib, sys; [compile(pathlib.Path(path).read_bytes(), path, "exec") for path in sys.argv[1:]]'; \
+	python3 -m unittest discover -s deploy/tests -p 'test_*.py' -v
 
 .PHONY: destroy
 destroy:

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ See the [Deployment Guide](./deploy/README.md) for prerequisites, cloud-specific
 
 ### Create a Sandbox
 
-Install the Python SDK from PyPI or source:
+Install the Python SDK. The default installation includes the
+`openyuanrong-sandbox` HTTP/RRT backend:
 
 ```bash
 # PyPI
@@ -113,7 +114,15 @@ python -m pip install akernel-sdk
 
 # Source
 python -m pip install ./sdk/python
+
+# Also install the actor backend
+python -m pip install "akernel-sdk[openyuanrong-sdk]"
 ```
+
+When the actor extra is installed, both backend packages are present and
+`openyuanrong-sandbox` remains the automatic default. Set
+`AKERNEL_BACKEND=openyuanrong-sdk` before importing `akernel_sdk` to select
+the actor backend.
 
 Configure the AKernel environment:
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ See the complete [basic usage example](./sdk/python/examples/basic_usage.py), th
 ### How It Works
 
 1. **Agent Submits Workload**: Through unified API or SDK
-2. **Scheduler Places Sandbox**: Selects a worker based on requested CPU, memory, and available capacity
+2. **Scheduler Places Sandbox**: Selects a worker based on requested CPU,
+   memory, optional GPU devices, and available capacity
 3. **Sandbox Created**: Prepares the rootfs and network and starts the selected sandbox runtime on the worker
 4. **Workload Executes**: In secure, isolated sandboxes
 5. **Resources Recycled**: Deletes the sandbox and returns its capacity to the cluster

--- a/builder/config/yr_services.yaml
+++ b/builder/config/yr_services.yaml
@@ -2,6 +2,18 @@
   kind: yrlib # Function type. Required. Process deployment supports yrlib only.
   description: this is the default service # Optional service description.
   functions: # Function definitions. Required.
+    rrt:
+      runtime: rust
+      rootfs:
+        runtime: runsc
+        type: local
+        path: /home/yuanrong/yr-runtime-rootfs.img
+        readonly: false
+        mountpoint: /var/task/code
+      bootstrap:
+        type: erofs
+        root: "/home/yuanrong/yr-runtime-rootfs.img"
+        entrypoint: "/__yuanrong/usr/bin/tini-static -- /__yuanrong/usr/local/bin/rrt-runtime"
     py311:
       runtime: python3.11
       rootfs:
@@ -40,6 +52,18 @@
         entrypoint: "/__yuanrong/usr/bin/tini-static -- sh /__yuanrong/home/entryfile.sh"
     py313:
       runtime: python3.13
+      rootfs:
+        runtime: runsc
+        type: local
+        path: /home/yuanrong/yr-runtime-rootfs.img
+        readonly: false
+        mountpoint: /var/task/code
+      bootstrap:
+        type: erofs
+        root: "/home/yuanrong/yr-runtime-rootfs.img"
+        entrypoint: "/__yuanrong/usr/bin/tini-static -- sh /__yuanrong/home/entryfile.sh"
+    py314:
+      runtime: python3.14
       rootfs:
         runtime: runsc
         type: local

--- a/builder/node.Dockerfile
+++ b/builder/node.Dockerfile
@@ -19,6 +19,7 @@ ARG AKERNEL_VERSION=unknown
 ARG AKERNEL_REVISION=unknown
 ARG OPEN_YR_CORE_WHEEL_URL=https://github.com/openYuanrong-mirror/yuanrong/releases/download/0.9.3/openyuanrong_core-0.9.3-py3-none-manylinux_2_31_x86_64.whl
 ARG OPEN_YR_CORE_WHEEL_SHA256=dd472bfa60d3d934056801ae011db7b1993cb19c5681da2395e7f1e2d84e58c3
+ARG LIBNVIDIA_CONTAINER_VERSION=1.19.1-1
 
 FROM ${KATA_BUILD_IMAGE} AS kata-runtime
 ARG KATA_RELEASE
@@ -94,6 +95,7 @@ ARG GVISOR_RELEASE_BASE_URL
 ARG OTELCOL_CONTRIB_URL
 ARG OPEN_YR_CORE_WHEEL_URL
 ARG OPEN_YR_CORE_WHEEL_SHA256
+ARG LIBNVIDIA_CONTAINER_VERSION
 ARG TARGETARCH
 ARG PIP_INDEX_URL=https://pypi.org/simple
 ENV DEBIAN_FRONTEND=noninteractive
@@ -104,6 +106,7 @@ RUN apt-get update && \
         curl \
         e2fsprogs \
         fuse3 \
+        gnupg \
         iproute2 \
         iptables \
         jq \
@@ -119,6 +122,25 @@ RUN apt-get update && \
         systemd-sysv \
         tzdata \
         xfsprogs && \
+    rm -rf /var/lib/apt/lists/*
+
+# sandboxd's gVisor GPU provider uses nvidia-container-cli for discovery and
+# the legacy prestart hook to inject the host driver into the private rootfs.
+RUN set -eux; \
+    curl -fsSL --retry 10 --retry-delay 2 --retry-all-errors \
+      https://nvidia.github.io/libnvidia-container/gpgkey \
+      | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg; \
+    curl -fsSL --retry 10 --retry-delay 2 --retry-all-errors \
+      https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
+      | sed \
+        's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+      > /etc/apt/sources.list.d/nvidia-container-toolkit.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      "libnvidia-container1=${LIBNVIDIA_CONTAINER_VERSION}" \
+      "libnvidia-container-tools=${LIBNVIDIA_CONTAINER_VERSION}" \
+      "nvidia-container-toolkit-base=${LIBNVIDIA_CONTAINER_VERSION}" \
+      "nvidia-container-toolkit=${LIBNVIDIA_CONTAINER_VERSION}"; \
     rm -rf /var/lib/apt/lists/*
 
 RUN if command -v update-alternatives >/dev/null 2>&1; then \

--- a/builder/node.Dockerfile
+++ b/builder/node.Dockerfile
@@ -6,7 +6,7 @@ ARG AKERNEL_NODE_BASE_IMAGE=ubuntu:24.04
 ARG AKERNEL_RUNTIME_IMAGE=akernel-runtime:local
 ARG SANDBOXD_BUILD_IMAGE=golang:1.25.5-bookworm
 ARG DISTILL_FS_BUILD_IMAGE=rust:1.85.0-bookworm
-ARG OPEN_YR_VERSION=0.9.2
+ARG OPEN_YR_VERSION=0.9.3
 ARG GVISOR_RELEASE=release-20260706.0
 ARG GVISOR_RELEASE_BASE_URL=https://storage.googleapis.com/gvisor/releases
 ARG KATA_BUILD_IMAGE=ubuntu:24.04
@@ -17,6 +17,8 @@ ARG OTELCOL_CONTRIB_VERSION=0.120.0
 ARG OTELCOL_CONTRIB_URL=https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${OTELCOL_CONTRIB_VERSION}/otelcol-contrib_${OTELCOL_CONTRIB_VERSION}_linux_amd64.tar.gz
 ARG AKERNEL_VERSION=unknown
 ARG AKERNEL_REVISION=unknown
+ARG OPEN_YR_CORE_WHEEL_URL=https://github.com/openYuanrong-mirror/yuanrong/releases/download/0.9.3/openyuanrong_core-0.9.3-py3-none-manylinux_2_31_x86_64.whl
+ARG OPEN_YR_CORE_WHEEL_SHA256=dd472bfa60d3d934056801ae011db7b1993cb19c5681da2395e7f1e2d84e58c3
 
 FROM ${KATA_BUILD_IMAGE} AS kata-runtime
 ARG KATA_RELEASE
@@ -90,6 +92,8 @@ ARG OPEN_YR_VERSION
 ARG GVISOR_RELEASE
 ARG GVISOR_RELEASE_BASE_URL
 ARG OTELCOL_CONTRIB_URL
+ARG OPEN_YR_CORE_WHEEL_URL
+ARG OPEN_YR_CORE_WHEEL_SHA256
 ARG TARGETARCH
 ARG PIP_INDEX_URL=https://pypi.org/simple
 ENV DEBIAN_FRONTEND=noninteractive
@@ -159,20 +163,26 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone
 
 
-ENV YR_INSTALLATION_DIR=/home/yuanrong
+ENV OPEN_YR_PYTHON_ROOT=/opt/openyuanrong \
+    YR_INSTALLATION_DIR=/opt/openyuanrong/yr \
+    PYTHONPATH=/opt/openyuanrong
 
-# Download and unpack the openyuanrong runtime tarball from the GitHub
-# release mirror. The .sha256 sidecar verifies the download before unpacking.
-RUN mkdir -p "${YR_INSTALLATION_DIR}" /tmp/yr-release && \
-    cd /tmp/yr-release && \
-    yr_tarball="openyuanrong-${OPEN_YR_VERSION}-linux-amd64.tar.gz" && \
-    curl -fSL --retry 10 --retry-delay 2 --retry-all-errors -O \
-      "https://github.com/openYuanrong-mirror/yuanrong/releases/download/${OPEN_YR_VERSION}/${yr_tarball}" && \
-    curl -fSL --retry 10 --retry-delay 2 --retry-all-errors -O \
-      "https://github.com/openYuanrong-mirror/yuanrong/releases/download/${OPEN_YR_VERSION}/${yr_tarball}.sha256" && \
-    sha256sum -c "${yr_tarball}.sha256" && \
-    tar -xzf "${yr_tarball}" -C "${YR_INSTALLATION_DIR}" --strip-components=1 && \
-    cd / && rm -rf /tmp/yr-release && \
+# Install the language-runtime-free core wheel into an isolated prefix.
+# Keep /home/yuanrong as the stable service/config path, but run the native
+# functionsystem/bin/yr shipped by the wheel instead of its console script.
+RUN mkdir -p "${OPEN_YR_PYTHON_ROOT}" /tmp/yr-release && \
+    yr_core_wheel="/tmp/yr-release/openyuanrong_core-0.9.3-py3-none-manylinux_2_31_x86_64.whl" && \
+    curl -fSL --retry 10 --retry-delay 2 --retry-all-errors \
+      "${OPEN_YR_CORE_WHEEL_URL}" -o "${yr_core_wheel}" && \
+    echo "${OPEN_YR_CORE_WHEEL_SHA256}  ${yr_core_wheel}" | sha256sum -c - && \
+    python3 -m pip install \
+      --break-system-packages \
+      --no-cache-dir \
+      --target "${OPEN_YR_PYTHON_ROOT}" \
+      "${yr_core_wheel}" && \
+    test -x "${YR_INSTALLATION_DIR}/functionsystem/bin/yr" && \
+    ln -sfn "${YR_INSTALLATION_DIR}" /home/yuanrong && \
+    rm -rf /tmp/yr-release && \
     ln -sf "${YR_INSTALLATION_DIR}/functionsystem/bin/yr" /usr/bin/yr
 
 COPY --from=runtime-image /yr-runtime-rootfs.img ${YR_INSTALLATION_DIR}/yr-runtime-rootfs.img

--- a/builder/runtime.Dockerfile
+++ b/builder/runtime.Dockerfile
@@ -3,11 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG AKERNEL_RUNTIME_BASE_IMAGE=ubuntu:24.04
-ARG UV_VERSION=0.7.13
+ARG UV_VERSION=0.11.32
 ARG PYTHON_310_VERSION=3.10.18
 ARG PYTHON_311_VERSION=3.11.13
 ARG PYTHON_312_VERSION=3.12.11
 ARG PYTHON_313_VERSION=3.13.5
+ARG PYTHON_314_VERSION=3.14.6
 
 FROM ${AKERNEL_RUNTIME_BASE_IMAGE} AS python-runtime-base
 
@@ -16,6 +17,7 @@ ARG PYTHON_310_VERSION
 ARG PYTHON_311_VERSION
 ARG PYTHON_312_VERSION
 ARG PYTHON_313_VERSION
+ARG PYTHON_314_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive \
     UV_CACHE_DIR=/tmp/uv-cache \
@@ -53,7 +55,8 @@ RUN uv python install \
         "${PYTHON_310_VERSION}" \
         "${PYTHON_311_VERSION}" \
         "${PYTHON_312_VERSION}" \
-        "${PYTHON_313_VERSION}"; \
+        "${PYTHON_313_VERSION}" \
+        "${PYTHON_314_VERSION}"; \
     rm -rf "${UV_CACHE_DIR}"
 
 RUN set -eux; \
@@ -61,7 +64,8 @@ RUN set -eux; \
         "3.10:${PYTHON_310_VERSION}" \
         "3.11:${PYTHON_311_VERSION}" \
         "3.12:${PYTHON_312_VERSION}" \
-        "3.13:${PYTHON_313_VERSION}"; do \
+        "3.13:${PYTHON_313_VERSION}" \
+        "3.14:${PYTHON_314_VERSION}"; do \
         py="${spec%%:*}"; \
         version="${spec#*:}"; \
         uv venv "/opt/venv-py${py}" --python "${version}" --seed; \
@@ -73,7 +77,7 @@ RUN set -eux; \
 
 FROM python-runtime-base AS runtime-rootfs
 
-ARG OPEN_YR_VERSION=0.9.2
+ARG OPEN_YR_VERSION=0.9.3
 ARG FASTAPI_VERSION=0.138.0
 ARG PYDANTIC_VERSION=2.13.4
 ARG UVICORN_VERSION=0.49.0
@@ -82,6 +86,7 @@ ARG PYTHON_310_VERSION
 ARG PYTHON_311_VERSION
 ARG PYTHON_312_VERSION
 ARG PYTHON_313_VERSION
+ARG PYTHON_314_VERSION
 
 RUN mkdir -p /var/task/code /__yuanrong && \
     ln -sfn /home /__yuanrong/home && \
@@ -107,7 +112,8 @@ RUN set -eux; \
             "fastapi==${FASTAPI_VERSION}" \
             "pydantic==${PYDANTIC_VERSION}" \
             "uvicorn==${UVICORN_VERSION}" \
-            "openyuanrong_sdk==${OPEN_YR_VERSION}" && break; \
+            "openyuanrong-sdk==${OPEN_YR_VERSION}" \
+            "openyuanrong-sandbox==${OPEN_YR_VERSION}" && break; \
         if [ "${attempt}" -ge 3 ]; then exit 1; fi; \
         sleep $((attempt * 5)); \
         attempt=$((attempt + 1)); \
@@ -128,7 +134,8 @@ RUN set -eux; \
             "fastapi==${FASTAPI_VERSION}" \
             "pydantic==${PYDANTIC_VERSION}" \
             "uvicorn==${UVICORN_VERSION}" \
-            "openyuanrong_sdk==${OPEN_YR_VERSION}" && break; \
+            "openyuanrong-sdk==${OPEN_YR_VERSION}" \
+            "openyuanrong-sandbox==${OPEN_YR_VERSION}" && break; \
         if [ "${attempt}" -ge 3 ]; then exit 1; fi; \
         sleep $((attempt * 5)); \
         attempt=$((attempt + 1)); \
@@ -149,7 +156,8 @@ RUN set -eux; \
             "fastapi==${FASTAPI_VERSION}" \
             "pydantic==${PYDANTIC_VERSION}" \
             "uvicorn==${UVICORN_VERSION}" \
-            "openyuanrong_sdk==${OPEN_YR_VERSION}" && break; \
+            "openyuanrong-sdk==${OPEN_YR_VERSION}" \
+            "openyuanrong-sandbox==${OPEN_YR_VERSION}" && break; \
         if [ "${attempt}" -ge 3 ]; then exit 1; fi; \
         sleep $((attempt * 5)); \
         attempt=$((attempt + 1)); \
@@ -170,7 +178,8 @@ RUN set -eux; \
             "fastapi==${FASTAPI_VERSION}" \
             "pydantic==${PYDANTIC_VERSION}" \
             "uvicorn==${UVICORN_VERSION}" \
-            "openyuanrong_sdk==${OPEN_YR_VERSION}" && break; \
+            "openyuanrong-sdk==${OPEN_YR_VERSION}" \
+            "openyuanrong-sandbox==${OPEN_YR_VERSION}" && break; \
         if [ "${attempt}" -ge 3 ]; then exit 1; fi; \
         sleep $((attempt * 5)); \
         attempt=$((attempt + 1)); \
@@ -180,10 +189,42 @@ RUN set -eux; \
         "/opt/python${py}"; \
     rm -rf "${UV_CACHE_DIR:-/tmp/uv-cache}"
 
+RUN set -eux; \
+    py="3.14"; version="${PYTHON_314_VERSION}"; \
+    attempt=1; \
+    while true; do \
+        uv pip install \
+            --no-cache-dir \
+            --index-url "${PIP_INDEX_URL}" \
+            --python "/opt/venv-py${py}/bin/python" \
+            "fastapi==${FASTAPI_VERSION}" \
+            "pydantic==${PYDANTIC_VERSION}" \
+            "uvicorn==${UVICORN_VERSION}" \
+            "openyuanrong-sdk==${OPEN_YR_VERSION}" \
+            "openyuanrong-sandbox==${OPEN_YR_VERSION}" && break; \
+        if [ "${attempt}" -ge 3 ]; then exit 1; fi; \
+        sleep $((attempt * 5)); \
+        attempt=$((attempt + 1)); \
+    done; \
+    ln -sfn \
+        "uv-python/cpython-${version}-linux-x86_64-gnu/bin/python${py}" \
+        "/opt/python${py}"; \
+    rm -rf "${UV_CACHE_DIR:-/tmp/uv-cache}"
+
+ARG RRT_RUNTIME_URL=https://github.com/openYuanrong-mirror/yuanrong/releases/download/0.9.3/rrt-runtime-amd64
+ARG RRT_RUNTIME_SHA256=89eb9271233e79f97b42b7b12cfd65e81404eb75b49d0e7a0b1ebe4977aae305
+
+RUN set -eux; \
+    curl -fSL --retry 5 --retry-delay 2 --retry-all-errors \
+        -o /tmp/rrt-runtime "${RRT_RUNTIME_URL}"; \
+    echo "${RRT_RUNTIME_SHA256}  /tmp/rrt-runtime" | sha256sum -c -; \
+    install -m 0755 /tmp/rrt-runtime /usr/local/bin/rrt-runtime; \
+    rm -f /tmp/rrt-runtime
+
 COPY ./builder/scripts/entryfile.sh /home/entryfile.sh
 RUN set -eux; \
     chmod 0755 /home/entryfile.sh; \
-    for py in 3.10 3.11 3.12 3.13; do \
+    for py in 3.10 3.11 3.12 3.13 3.14; do \
         "/opt/venv-py${py}/bin/python" -m compileall -q \
             "/opt/venv-py${py}/lib/python${py}/site-packages"; \
     done

--- a/builder/scripts/entryfile.sh
+++ b/builder/scripts/entryfile.sh
@@ -21,8 +21,11 @@ case "$RUNTIME_ENV" in
     python3.13)
         PY_VERSION=3.13
         ;;
+    python3.14)
+        PY_VERSION=3.14
+        ;;
     *)
-        echo "unsupported YR_LANGUAGE=${RUNTIME_ENV}; supported runtimes: python3.10, python3.11, python3.12, python3.13" >&2
+        echo "unsupported YR_LANGUAGE=${RUNTIME_ENV}; supported runtimes: python3.10, python3.11, python3.12, python3.13, python3.14" >&2
         exit 127
         ;;
 esac

--- a/builder/scripts/yr_node_bootstrap.sh
+++ b/builder/scripts/yr_node_bootstrap.sh
@@ -43,6 +43,7 @@ if [  "x${AKS_LOCAL_MODE}" == "xtrue" ]; then
         --enable_inherit_env false \
         --npu_collection_mode off \
         --enable_distributed_master false \
+        --metrics_collector_type external \
         --enable_traefik_registry=${ENABLE_TRAEFIK_REGISTRY} \
         --traefik_enable_tls=${TRAEFIK_ENABLE_TLS:-false} \
         --traefik_etcd_prefix=traefik \

--- a/builder/systemd_services/yuanrong.service
+++ b/builder/systemd_services/yuanrong.service
@@ -8,6 +8,7 @@ PassEnvironment=ETCD_PORT ETCD_PEER_PORT ETCD_ADDRESS HOSTNAME AKS_LOCAL_MODE LI
 Environment="CONTAINER_EP=unix:///run/sandboxd/sandboxd.sock"
 Environment="YR_ENV_FILE=/dev/function/config"
 Environment="RUNTIME_HOME_DIR=/home/yuanrong/runtime"
+Environment="YR_NOSET_CUDA_VISIBLE_DEVICES=1"
 ExecStartPre=-/bin/mkdir -p /home/yuanrong/runtime
 ExecStart=/usr/bin/bash /home/yuanrong/yr_node_bootstrap.sh
 

--- a/deploy/akernel/charts/core/templates/traefik/configmap.yaml
+++ b/deploy/akernel/charts/core/templates/traefik/configmap.yaml
@@ -81,7 +81,14 @@ data:
         frontend-terminal:
           entryPoints:
             - websecure
-          rule: "PathPrefix(`/terminal`) || PathPrefix(`/api/instances`) || PathPrefix(`/api/jobs`) || PathPrefix(`/functions`) || PathPrefix(`/api-docs`) || PathPrefix(`/admin/v1/functions`) || PathPrefix(`/serverless/v1/functions`) || PathPrefix(`/serverless/v1/stream`) || PathPrefix(`/serverless/v1/componentshealth`) || PathPrefix(`/serverless/v1/posix`) || PathPrefix(`/serverless/v2`) || PathPrefix(`/frontend/v1/instance`) || PathPrefix(`/datasystem/v1`) || PathPrefix(`/app/v1`) || PathPrefix(`/client/v1/lease`) || PathPrefix(`/invocations`) || PathPrefix(`/global-scheduler`) || Path(`/healthz`)"
+          rule: "PathPrefix(`/terminal`) || PathPrefix(`/api/instances`) || PathPrefix(`/api/jobs`) || PathPrefix(`/api/sandbox`) || PathPrefix(`/functions`) || PathPrefix(`/api-docs`) || PathPrefix(`/admin/v1/functions`) || PathPrefix(`/serverless/v1/functions`) || PathPrefix(`/serverless/v1/stream`) || PathPrefix(`/serverless/v1/componentshealth`) || PathPrefix(`/serverless/v1/posix`) || PathPrefix(`/serverless/v2`) || PathPrefix(`/frontend/v1/instance`) || PathPrefix(`/datasystem/v1`) || PathPrefix(`/app/v1`) || PathPrefix(`/client/v1/lease`) || PathPrefix(`/invocations`) || PathPrefix(`/global-scheduler`) || Path(`/healthz`)"
+          service: {{ if .Values.frontend.enabled }}akernel-frontend{{ else }}akernel-master{{ end }}
+          tls: {}
+        direct-router:
+          entryPoints:
+            - websecure
+          rule: "PathPrefix(`/direct/`) || Path(`/direct`)"
+          priority: 100
           service: {{ if .Values.frontend.enabled }}akernel-frontend{{ else }}akernel-master{{ end }}
           tls: {}
         {{- if .Values.traefik.grafana.enabled }}

--- a/deploy/standalone/config/sandboxd_config.toml
+++ b/deploy/standalone/config/sandboxd_config.toml
@@ -59,7 +59,6 @@ oss_auths_path="/home/akernel/sandboxd/config/oss_auths.json"
 registry_auths_path="/home/akernel/sandboxd/config/registry_auths.json"
 cgroup_memory_limit="64GiB"
 
-# No [plugin.node_resource] section: standalone/local mode does not report
-# node resources to a scheduler, so sandboxd skips the node-resource module
-# (and does not bind /var/run/resource.sock). Add the section back to enable
-# it.
+[plugin.node_resource]
+provider="cgroup"
+sock_path="/var/run/resource.sock"

--- a/deploy/standalone/start.sh
+++ b/deploy/standalone/start.sh
@@ -279,7 +279,14 @@ http:
     akernel-frontend:
       entryPoints:
         - websecure
-      rule: "PathPrefix(\`/terminal\`) || PathPrefix(\`/api/instances\`) || PathPrefix(\`/api/jobs\`) || PathPrefix(\`/functions\`) || PathPrefix(\`/api-docs\`) || PathPrefix(\`/admin/v1/functions\`) || PathPrefix(\`/serverless/v1/functions\`) || PathPrefix(\`/serverless/v1/stream\`) || PathPrefix(\`/serverless/v1/componentshealth\`) || PathPrefix(\`/serverless/v1/posix\`) || PathPrefix(\`/serverless/v2\`) || PathPrefix(\`/frontend/v1/instance\`) || PathPrefix(\`/datasystem/v1\`) || PathPrefix(\`/app/v1\`) || PathPrefix(\`/client/v1/lease\`) || PathPrefix(\`/invocations\`) || PathPrefix(\`/global-scheduler\`) || Path(\`/healthz\`)"
+      rule: "PathPrefix(\`/terminal\`) || PathPrefix(\`/api/instances\`) || PathPrefix(\`/api/jobs\`) || PathPrefix(\`/api/sandbox\`) || PathPrefix(\`/functions\`) || PathPrefix(\`/api-docs\`) || PathPrefix(\`/admin/v1/functions\`) || PathPrefix(\`/serverless/v1/functions\`) || PathPrefix(\`/serverless/v1/stream\`) || PathPrefix(\`/serverless/v1/componentshealth\`) || PathPrefix(\`/serverless/v1/posix\`) || PathPrefix(\`/serverless/v2\`) || PathPrefix(\`/frontend/v1/instance\`) || PathPrefix(\`/datasystem/v1\`) || PathPrefix(\`/app/v1\`) || PathPrefix(\`/client/v1/lease\`) || PathPrefix(\`/invocations\`) || PathPrefix(\`/global-scheduler\`) || Path(\`/healthz\`)"
+      service: akernel-frontend
+      tls: {}
+    direct-router:
+      entryPoints:
+        - websecure
+      rule: "PathPrefix(\`/direct/\`) || Path(\`/direct\`)"
+      priority: 100
       service: akernel-frontend
       tls: {}
 

--- a/deploy/standalone/start.sh
+++ b/deploy/standalone/start.sh
@@ -26,6 +26,7 @@ LITEBUS_DATA_KEY=""
 DOCKER_CMD=""
 DOCKER_PREFIX=()
 PROXY_RUN_ARGS=()
+GPU_RUN_ARGS=()
 
 # Colors for output
 RED='\033[0;31m'
@@ -74,6 +75,19 @@ check_prerequisites() {
     fi
 
     log_info "${DOCKER_CMD} is available"
+
+    if [[ "${DOCKER_CMD}" = "docker" && -c /dev/nvidiactl ]]; then
+        if "${DOCKER_PREFIX[@]}" ${DOCKER_CMD} info \
+            --format '{{json .Runtimes}}' 2> /dev/null | grep -q '"nvidia"'; then
+            GPU_RUN_ARGS=(
+                --gpus all
+                -e NVIDIA_DRIVER_CAPABILITIES=compute,utility
+            )
+            log_info "NVIDIA container runtime detected; exposing all GPUs to the AKernel node"
+        else
+            log_warn "NVIDIA GPU detected but Docker's nvidia runtime is not configured; GPU sandboxes will not be advertised"
+        fi
+    fi
 
     if [[ ! -c /dev/kvm ]]; then
         log_warn "/dev/kvm is unavailable; standalone will support runsc but will not advertise the Kata runtime"
@@ -229,6 +243,7 @@ start_node_container() {
         -e TZ=Asia/Shanghai \
         -e ENABLE_TRACE="${ENABLE_TRACE:-false}" \
         -e ENABLE_METRICS="${ENABLE_METRICS:-false}" \
+        "${GPU_RUN_ARGS[@]}" \
         "${PROXY_RUN_ARGS[@]}" \
         --entrypoint=/usr/local/bin/akernel-entrypoint \
         -v "${DATA_DIR}:/home/akernel" \

--- a/deploy/tests/test_traefik_routes.py
+++ b/deploy/tests/test_traefik_routes.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 Ant Group Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Keep Helm and standalone sandbox routes aligned."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+HELM_CONFIG = (
+    ROOT
+    / "deploy/akernel/charts/core/templates/traefik/configmap.yaml"
+).read_text(encoding="utf-8")
+STANDALONE_CONFIG = (
+    ROOT / "deploy/standalone/start.sh"
+).read_text(encoding="utf-8")
+
+
+class TraefikSandboxRoutesTest(unittest.TestCase):
+    def test_sandbox_control_api_routes_to_frontend(self) -> None:
+        self.assertIn("PathPrefix(`/api/sandbox`)", HELM_CONFIG)
+        self.assertIn(r"PathPrefix(\`/api/sandbox\`)", STANDALONE_CONFIG)
+
+    def test_direct_api_uses_a_high_priority_frontend_router(self) -> None:
+        self.assertIn(
+            'rule: "PathPrefix(`/direct/`) || Path(`/direct`)"',
+            HELM_CONFIG,
+        )
+        self.assertIn(
+            r'rule: "PathPrefix(\`/direct/\`) || Path(\`/direct\`)"',
+            STANDALONE_CONFIG,
+        )
+        self.assertIn("priority: 100", HELM_CONFIG)
+        self.assertIn("priority: 100", STANDALONE_CONFIG)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,6 +1,11 @@
 # AKernel Python SDK
 
-`akernel-sdk` is the Python interface for creating and managing remote AKernel sandboxes. Applications use one stable API for commands, files, interactive PTYs, port forwarding, and reverse tunnels. The current implementation uses `openYuanrong` as its backend adapter; backend-specific handles and namespaces are not part of the public API.
+`akernel-sdk` is the Python interface for creating and managing remote AKernel
+sandboxes. Applications use one stable API for commands, files, interactive
+PTYs, port forwarding, and reverse tunnels. It supports both the
+`openyuanrong-sandbox` HTTP/RRT backend and the actor-based
+`openyuanrong-sdk` backend; backend-native handles, value types, and namespaces
+are not part of the public API.
 
 ## Navigation
 
@@ -18,10 +23,14 @@
 
 ## Install and configure
 
-AKernel SDK 0.1.0 requires Python 3.10 or newer.
+AKernel SDK requires Python 3.10 or newer. The default installation includes
+the `openyuanrong-sandbox` HTTP/RRT backend:
 
 ```bash
 pip install akernel-sdk
+
+# Also install the actor-based backend:
+pip install "akernel-sdk[openyuanrong-sdk]"
 ```
 
 To install from a source checkout:
@@ -29,6 +38,36 @@ To install from a source checkout:
 ```bash
 python -m pip install ./sdk/python
 ```
+
+During development, install `openyuanrong-sandbox 0.9.3` from PyPI:
+
+```bash
+python -m pip install \
+  --index-url https://pypi.org/simple \
+  "openyuanrong-sandbox==0.9.3"
+python -m pip install -e "./sdk/python[dev]"
+```
+
+The `openyuanrong-sandbox` extra remains as a compatibility alias, so
+`pip install "akernel-sdk[openyuanrong-sandbox]"` is equivalent to the plain
+installation. Python extras only add dependencies; consequently,
+`pip install "akernel-sdk[openyuanrong-sdk]"` installs both backends. Select
+the actor backend with `AKERNEL_BACKEND` before importing `akernel_sdk`.
+
+Backend selection happens once when `akernel_sdk` is imported:
+
+1. `AKERNEL_BACKEND`, when set;
+2. installed `openyuanrong-sandbox`;
+3. installed `openyuanrong-sdk`.
+
+Use the canonical identifier to override auto-detection before import:
+
+```bash
+export AKERNEL_BACKEND=openyuanrong-sdk
+```
+
+`akernel_sdk.get_backend()` reports the selected identifier without importing
+or initializing the backend.
 
 Configure the public AKernel entrypoint and a signed JWT token:
 
@@ -82,7 +121,13 @@ Sandbox(
 )
 ```
 
-`cpu` is measured in millicores and `memory` in MiB. A zero CPU or memory limit means the limit follows the corresponding request. A positive limit must not be smaller than its request.
+`cpu` is measured in millicores and `memory` in MiB. A zero CPU or memory
+limit means the limit follows the corresponding request. A positive limit
+must not be smaller than its request. `cwd`, when provided, must be an absolute
+POSIX path.
+
+`schedule_timeout=-1` is supported only by `openyuanrong-sdk`.
+`openyuanrong-sandbox` rejects it before creating a remote sandbox.
 
 ## Sandbox runtimes
 
@@ -133,7 +178,9 @@ handle.close_stdin()
 result = handle.wait(timeout=15)
 ```
 
-Foreground commands use one actor RPC with the configured timeout. Background commands return a handle whose `wait()` method also performs one actor RPC.
+Foreground commands return a backend-neutral `CommandResult`. Background
+commands return an AKernel `CommandHandle`; its lifecycle operations are
+delegated to the selected backend.
 
 ## Filesystem
 
@@ -234,8 +281,10 @@ the loopback HTTP listener used inside the sandbox. Consequently,
 
 For an HTTPS target, the SDK-side tunnel client performs the TLS handshake and
 certificate verification. The sandbox application talks only to its loopback
-HTTP listener. AKernel 0.1.0 supports one HTTP/WebSocket reverse tunnel per
-sandbox; it does not expose a general TCP tunnel.
+HTTP listener. AKernel supports one HTTP/HTTPS reverse tunnel per sandbox and
+does not expose a general TCP tunnel. The HTTP/RRT backend owns the fixed
+internal ports 8765 and 8766 and rejects custom port values. Reverse WebSocket
+forwarding and custom tunnel ports currently require `openyuanrong-sdk`.
 
 ## Rootfs and mounts
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -118,6 +118,8 @@ Sandbox(
     reverse_tunnel: HttpReverseTunnel | None = None,
     detached: bool = False,
     node_id: str | None = None,
+    *,
+    xpu: str | None = None,
 )
 ```
 
@@ -128,6 +130,23 @@ POSIX path.
 
 `schedule_timeout=-1` is supported only by `openyuanrong-sdk`.
 `openyuanrong-sandbox` rejects it before creating a remote sandbox.
+
+Request whole GPU devices with `xpu="type:model:count"`:
+
+```python
+with Sandbox(xpu="gpu:a10:1") as sandbox:
+    print(sandbox.commands.run("nvidia-smi -L").stdout)
+```
+
+The current XPU API supports `gpu`. The model is the scheduler-visible,
+normalized value reported by the node
+resource endpoint (for example, NVIDIA A10 is reported as `a10`). Use
+`xpu="gpu::1"` to accept any GPU model. `count` must be a positive integer.
+Both backends use the same public format; the actor backend translates it to
+openYuanRong's `GPU/<model>/count` resource key. The cluster must advertise
+enough matching GPU resources or creation fails during scheduling.
+See [`examples/gpu_sandbox.py`](./examples/gpu_sandbox.py) for a runnable
+example.
 
 ## Sandbox runtimes
 
@@ -379,6 +398,7 @@ Maintained examples are under [`examples/`](./examples):
 - `basic_usage.py`
 - `command_stdin.py`
 - `custom_image.py`
+- `gpu_sandbox.py`
 - `named_sandbox.py`
 - `pty.py`
 - `port_forwarding.py`

--- a/sdk/python/akernel_sdk/__init__.py
+++ b/sdk/python/akernel_sdk/__init__.py
@@ -16,6 +16,13 @@
 
 import importlib
 
+from ._backends.errors import (
+    BackendNotInstalledError,
+    BackendOperationError,
+    InvalidBackendError,
+    UnsupportedBackendFeatureError,
+)
+from ._backends.registry import selected_backend
 from .types import (
     CommandInfo,
     CommandResult,
@@ -42,6 +49,11 @@ __all__ = [
     "PtySession",
     "PtyError",
     "resources",
+    "get_backend",
+    "InvalidBackendError",
+    "BackendNotInstalledError",
+    "UnsupportedBackendFeatureError",
+    "BackendOperationError",
 ]
 
 _LAZY_IMPORTS = {
@@ -50,8 +62,14 @@ _LAZY_IMPORTS = {
     "Pty": (".pty", "Pty"),
     "PtySession": (".pty", "PtySession"),
     "PtyError": (".pty", "PtyError"),
-    "resources": ("._openyuanrong", "resources"),
+    "resources": ("._resources", "resources"),
 }
+
+
+def get_backend() -> str | None:
+    """Return the backend selected during package import without loading it."""
+
+    return selected_backend()
 
 
 def __getattr__(name: str) -> object:

--- a/sdk/python/akernel_sdk/_addresses.py
+++ b/sdk/python/akernel_sdk/_addresses.py
@@ -153,10 +153,15 @@ def exec_endpoint_from_env() -> Endpoint:
     """Return the endpoint used by the exec WebSocket (/terminal/ws).
 
     File copy uses the frontend exec WebSocket.  If users set an explicit
-    gateway override, respect it; otherwise use the API endpoint so the
-    default cluster/public path is WSS on 443 or the explicit server port.
+    AKERNEL gateway override, respect it; otherwise use the API endpoint so
+    the default cluster/public path is WSS on 443 or the explicit server port.
+
+    Do not use YR_GATEWAY_ADDRESS here.  The openyuanrong-sandbox backend sets
+    that variable internally while it initializes the RRT client, so treating
+    it as a user override would incorrectly move PTY and file-copy traffic
+    from the frontend API endpoint to the public port-forwarding gateway.
     """
-    override = _gateway_override_raw()
+    override = os.environ.get("AKERNEL_GATEWAY_ADDRESS", "").strip()
     if override:
         return _parse_endpoint(
             override,

--- a/sdk/python/akernel_sdk/_backends/__init__.py
+++ b/sdk/python/akernel_sdk/_backends/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026 Ant Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Internal backend interfaces and implementations."""

--- a/sdk/python/akernel_sdk/_backends/base.py
+++ b/sdk/python/akernel_sdk/_backends/base.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026 Ant Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-neutral contracts used by the public AKernel SDK."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Literal, Protocol
+
+from .._addresses import Endpoint
+from ..types import (
+    CommandInfo,
+    CommandResult,
+    EntryInfo,
+    HttpReverseTunnel,
+    Mount,
+    S3Config,
+    SandboxInfo,
+)
+
+
+class Capability(Enum):
+    """Features whose availability differs between backends."""
+
+    KATA_RUNTIME = auto()
+    S3_ROOTFS = auto()
+    NODE_PLACEMENT = auto()
+    UNBOUNDED_SCHEDULE_TIMEOUT = auto()
+    CUSTOM_REVERSE_TUNNEL_PORTS = auto()
+    REVERSE_WEBSOCKET = auto()
+
+
+@dataclass(frozen=True)
+class BackendConfig:
+    """Normalized connection configuration passed to one backend."""
+
+    api_endpoint: Endpoint
+    gateway_endpoint: Endpoint
+    token: str = field(repr=False)
+
+
+@dataclass(frozen=True)
+class SandboxSpec:
+    """Validated, immutable inputs for creating a sandbox."""
+
+    image: str | None
+    rootfs: S3Config | None
+    runtime: Literal["runsc", "kata"]
+    cpu: int
+    memory: int
+    cpu_limit: int
+    mem_limit: int
+    idle_timeout: int
+    schedule_timeout: int
+    env: Mapping[str, str]
+    name: str | None
+    command_cwd: str | None
+    port_forwardings: tuple[int, ...]
+    mounts: tuple[Mount, ...]
+    reverse_tunnel: HttpReverseTunnel | None
+    detached: bool
+    node_id: str | None
+
+
+class CommandsDriver(Protocol):
+    """Backend command operations consumed by :class:`Commands`."""
+
+    def run(
+        self,
+        cmd: str,
+        *,
+        envs: Mapping[str, str] | None,
+        cwd: str | None,
+        timeout: int,
+    ) -> CommandResult: ...
+
+    def start(
+        self,
+        cmd: str,
+        *,
+        envs: Mapping[str, str] | None,
+        cwd: str | None,
+        stdin: bool,
+    ) -> int: ...
+
+    def wait(self, pid: int, timeout: int | None) -> CommandResult: ...
+
+    def kill(self, pid: int) -> bool: ...
+
+    def send_stdin(self, pid: int, data: str, eof: bool) -> None: ...
+
+    def list(self) -> list[CommandInfo]: ...
+
+
+class FilesystemDriver(Protocol):
+    """Backend filesystem operations consumed by :class:`Filesystem`."""
+
+    def read(self, path: str, *, binary: bool) -> str | bytes: ...
+
+    def write(self, path: str, data: str | bytes) -> EntryInfo: ...
+
+    def list(self, path: str, depth: int) -> list[EntryInfo]: ...
+
+    def exists(self, path: str) -> bool: ...
+
+    def remove(self, path: str) -> None: ...
+
+    def rename(self, old_path: str, new_path: str) -> EntryInfo: ...
+
+    def make_dir(self, path: str) -> bool: ...
+
+    def get_info(self, path: str) -> EntryInfo: ...
+
+    def copy_from_local(self, local_path: str, remote_path: str) -> None: ...
+
+    def copy_to_local(self, remote_path: str, local_path: str) -> None: ...
+
+
+class BackendSession(Protocol):
+    """One backend-native remote sandbox hidden behind AKernel types."""
+
+    @property
+    def id(self) -> str: ...
+
+    @property
+    def commands(self) -> CommandsDriver: ...
+
+    @property
+    def files(self) -> FilesystemDriver: ...
+
+    def is_running(self) -> bool: ...
+
+    def get_info(self) -> SandboxInfo: ...
+
+    def terminate(self) -> None: ...
+
+    def close(self) -> None: ...
+
+
+class Backend(Protocol):
+    """Process-level backend factory and shared resource owner."""
+
+    name: str
+    namespace: str
+    capabilities: frozenset[Capability]
+
+    def create(self, spec: SandboxSpec) -> BackendSession: ...
+
+    def delete_named(self, name: str) -> None: ...
+
+    def close(self) -> None: ...

--- a/sdk/python/akernel_sdk/_backends/base.py
+++ b/sdk/python/akernel_sdk/_backends/base.py
@@ -74,6 +74,7 @@ class SandboxSpec:
     reverse_tunnel: HttpReverseTunnel | None
     detached: bool
     node_id: str | None
+    xpu: str | None
 
 
 class CommandsDriver(Protocol):

--- a/sdk/python/akernel_sdk/_backends/errors.py
+++ b/sdk/python/akernel_sdk/_backends/errors.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 Ant Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Stable errors raised at the AKernel backend boundary."""
+
+
+class InvalidBackendError(ValueError):
+    """The configured backend identifier is not supported."""
+
+
+class BackendNotInstalledError(ImportError):
+    """The selected backend dependency is not installed."""
+
+
+class UnsupportedBackendFeatureError(ValueError):
+    """The selected backend cannot preserve a requested AKernel feature."""
+
+
+class BackendOperationError(RuntimeError):
+    """A backend operation failed."""

--- a/sdk/python/akernel_sdk/_backends/openyuanrong_sandbox.py
+++ b/sdk/python/akernel_sdk/_backends/openyuanrong_sandbox.py
@@ -1,0 +1,386 @@
+# Copyright (c) 2026 Ant Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Adapter for the frontend/RRT ``openyuanrong-sandbox`` backend."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any
+
+import yr_sandbox
+
+from ..types import CommandInfo, CommandResult, EntryInfo, SandboxInfo
+from .base import (
+    Backend,
+    BackendConfig,
+    BackendSession,
+    Capability,
+    SandboxSpec,
+)
+from .errors import BackendOperationError, UnsupportedBackendFeatureError
+
+_NAMESPACE = "default"
+_DEFAULT_REVERSE_PORT = 8765
+_DEFAULT_LISTEN_PORT = 8766
+
+
+def _convert_error(operation: str, error: Exception) -> BackendOperationError:
+    return BackendOperationError(f"{operation} failed: {error}")
+
+
+def _command_result(value: Any) -> CommandResult:
+    return CommandResult(
+        stdout=str(value.stdout),
+        stderr=str(value.stderr),
+        exit_code=int(value.exit_code),
+    )
+
+
+def _command_info(value: Any) -> CommandInfo:
+    return CommandInfo(
+        pid=int(value.pid),
+        command=str(value.command),
+        running=bool(value.running),
+    )
+
+
+def _entry_info(value: Any) -> EntryInfo:
+    return EntryInfo(
+        name=str(value.name),
+        path=str(value.path),
+        type=str(value.type),
+        size=int(value.size),
+        permissions=str(value.permissions),
+        modified_time=float(value.modified_time),
+    )
+
+
+class _CommandsDriver:
+    def __init__(self, commands: Any) -> None:
+        self._commands = commands
+        self._handles: dict[int, Any] = {}
+
+    def run(
+        self,
+        cmd: str,
+        *,
+        envs: Mapping[str, str] | None,
+        cwd: str | None,
+        timeout: int,
+    ) -> CommandResult:
+        try:
+            value = self._commands.run(
+                cmd,
+                envs=dict(envs) if envs is not None else None,
+                cwd=cwd,
+                timeout=timeout,
+            )
+            return _command_result(value)
+        except Exception as error:
+            raise _convert_error("command execution", error) from error
+
+    def start(
+        self,
+        cmd: str,
+        *,
+        envs: Mapping[str, str] | None,
+        cwd: str | None,
+        stdin: bool,
+    ) -> int:
+        try:
+            handle = self._commands.run(
+                cmd,
+                background=True,
+                envs=dict(envs) if envs is not None else None,
+                cwd=cwd,
+                stdin=stdin,
+            )
+        except Exception as error:
+            raise _convert_error("background command start", error) from error
+        pid = int(handle.pid)
+        self._handles[pid] = handle
+        return pid
+
+    def wait(self, pid: int, timeout: int | None) -> CommandResult:
+        handle = self._handles.get(pid)
+        if handle is None:
+            raise BackendOperationError(f"no command handle for pid {pid}")
+        try:
+            return _command_result(handle.wait(timeout))
+        except Exception as error:
+            raise _convert_error(f"wait for process {pid}", error) from error
+
+    def kill(self, pid: int) -> bool:
+        try:
+            return bool(self._commands.kill(pid))
+        except Exception as error:
+            raise _convert_error(f"kill process {pid}", error) from error
+
+    def send_stdin(self, pid: int, data: str, eof: bool) -> None:
+        try:
+            self._commands.send_stdin(pid, data, eof)
+        except Exception as error:
+            raise _convert_error(f"send stdin to process {pid}", error) from error
+
+    def list(self) -> list[CommandInfo]:
+        try:
+            return [_command_info(value) for value in self._commands.list()]
+        except Exception as error:
+            raise _convert_error("list processes", error) from error
+
+
+class _FilesystemDriver:
+    def __init__(self, files: Any) -> None:
+        self._files = files
+
+    def read(self, path: str, *, binary: bool) -> str | bytes:
+        try:
+            return self._files.read(path, format="bytes" if binary else "text")
+        except Exception as error:
+            raise _convert_error(f"read {path}", error) from error
+
+    def write(self, path: str, data: str | bytes) -> EntryInfo:
+        try:
+            return _entry_info(self._files.write(path, data))
+        except Exception as error:
+            raise _convert_error(f"write {path}", error) from error
+
+    def list(self, path: str, depth: int) -> list[EntryInfo]:
+        try:
+            return [_entry_info(value) for value in self._files.list(path, depth)]
+        except Exception as error:
+            raise _convert_error(f"list {path}", error) from error
+
+    def exists(self, path: str) -> bool:
+        try:
+            return bool(self._files.exists(path))
+        except Exception as error:
+            raise _convert_error(f"check {path}", error) from error
+
+    def remove(self, path: str) -> None:
+        try:
+            self._files.remove(path)
+        except Exception as error:
+            raise _convert_error(f"remove {path}", error) from error
+
+    def rename(self, old_path: str, new_path: str) -> EntryInfo:
+        try:
+            return _entry_info(self._files.rename(old_path, new_path))
+        except Exception as error:
+            raise _convert_error(f"rename {old_path}", error) from error
+
+    def make_dir(self, path: str) -> bool:
+        try:
+            return bool(self._files.make_dir(path))
+        except Exception as error:
+            raise _convert_error(f"create directory {path}", error) from error
+
+    def get_info(self, path: str) -> EntryInfo:
+        try:
+            return _entry_info(self._files.get_info(path))
+        except Exception as error:
+            raise _convert_error(f"get info for {path}", error) from error
+
+    def copy_from_local(self, local_path: str, remote_path: str) -> None:
+        try:
+            self._files.copy_from_local(local_path, remote_path)
+        except FileNotFoundError:
+            raise
+        except Exception as error:
+            raise _convert_error(
+                f"copy {local_path} to {remote_path}", error
+            ) from error
+
+    def copy_to_local(self, remote_path: str, local_path: str) -> None:
+        try:
+            self._files.copy_to_local(remote_path, local_path)
+        except Exception as error:
+            raise _convert_error(
+                f"copy {remote_path} to {local_path}", error
+            ) from error
+
+
+class _Session:
+    def __init__(self, sandbox: Any, *, detached: bool) -> None:
+        self.id = str(sandbox.id)
+        self.commands = _CommandsDriver(sandbox.commands)
+        self.files = _FilesystemDriver(sandbox.files)
+        self._sandbox = sandbox
+        self._detached = detached
+        self._terminated = False
+        self._closed = False
+
+    def is_running(self) -> bool:
+        if self._terminated or self._closed:
+            return False
+        return bool(self._sandbox.is_running())
+
+    def get_info(self) -> SandboxInfo:
+        try:
+            value = self._sandbox.get_info()
+        except Exception as error:
+            raise _convert_error("get sandbox info", error) from error
+        return SandboxInfo(
+            id=str(value.id),
+            state=str(value.state),
+            cpu=value.cpu,
+            memory=value.memory,
+            image=value.image,
+        )
+
+    def terminate(self) -> None:
+        if self._terminated:
+            return
+        try:
+            if self._detached:
+                yr_sandbox.Sandbox.delete(self.id)
+            else:
+                self._sandbox.kill()
+        except Exception as error:
+            raise _convert_error("terminate sandbox", error) from error
+        finally:
+            self._terminated = True
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        try:
+            self._sandbox.kill()
+        except Exception as error:
+            raise _convert_error("close sandbox resources", error) from error
+        finally:
+            self._closed = True
+
+
+class OpenYuanRongSandboxBackend:
+    """HTTP/RRT backend implemented by ``openyuanrong-sandbox``."""
+
+    name = "openyuanrong-sandbox"
+    namespace = _NAMESPACE
+    capabilities = frozenset(
+        {
+            Capability.KATA_RUNTIME,
+            Capability.S3_ROOTFS,
+            Capability.NODE_PLACEMENT,
+        }
+    )
+
+    def __init__(self, config: BackendConfig) -> None:
+        os.environ["YR_SERVER_ADDRESS"] = config.api_endpoint.authority()
+        os.environ["YR_TLS"] = "1" if config.api_endpoint.use_tls else "0"
+        os.environ["YR_GATEWAY_ADDRESS"] = config.gateway_endpoint.authority()
+        os.environ["YR_GATEWAY_TLS"] = (
+            "1" if config.gateway_endpoint.use_tls else "0"
+        )
+        os.environ["YR_TOKEN"] = config.token
+
+    def _validate(self, spec: SandboxSpec) -> None:
+        if spec.schedule_timeout == -1:
+            raise UnsupportedBackendFeatureError(
+                "Backend 'openyuanrong-sandbox' does not support "
+                "schedule_timeout=-1. Use a positive scheduling timeout or "
+                "select 'openyuanrong-sdk'."
+            )
+        tunnel = spec.reverse_tunnel
+        if tunnel is not None and (
+            tunnel.reverse_port != _DEFAULT_REVERSE_PORT
+            or tunnel.listen_port != _DEFAULT_LISTEN_PORT
+        ):
+            raise UnsupportedBackendFeatureError(
+                "Backend 'openyuanrong-sandbox' supports only reverse tunnel "
+                "ports 8765 and 8766."
+            )
+
+    def create(self, spec: SandboxSpec) -> BackendSession:
+        self._validate(spec)
+        rootfs = None
+        if spec.rootfs is not None:
+            rootfs = yr_sandbox.S3Config(
+                endpoint=spec.rootfs.endpoint,
+                bucket=spec.rootfs.bucket,
+                object=spec.rootfs.object,
+                access_key=spec.rootfs.access_key,
+                secret_key=spec.rootfs.secret_key,
+            )
+        mounts = [
+            yr_sandbox.Mount(
+                target=mount.target,
+                image_url=mount.image_url,
+                s3_config=(
+                    yr_sandbox.S3Config(
+                        endpoint=mount.s3_config.endpoint,
+                        bucket=mount.s3_config.bucket,
+                        object=mount.s3_config.object,
+                        access_key=mount.s3_config.access_key,
+                        secret_key=mount.s3_config.secret_key,
+                    )
+                    if mount.s3_config is not None
+                    else None
+                ),
+                type=mount.type,
+            )
+            for mount in spec.mounts
+        ]
+        create_timeout = max(60, spec.schedule_timeout + 30)
+        try:
+            sandbox = yr_sandbox.Sandbox(
+                image=spec.image,
+                rootfs=rootfs,
+                runtime=spec.runtime,
+                cpu=spec.cpu,
+                memory=spec.memory,
+                cpu_limit=spec.cpu_limit,
+                mem_limit=spec.mem_limit,
+                idle_timeout=spec.idle_timeout,
+                schedule_timeout=spec.schedule_timeout,
+                env=dict(spec.env),
+                name=spec.name,
+                cwd=spec.command_cwd,
+                port_forwardings=list(spec.port_forwardings),
+                mounts=mounts,
+                upstream=(
+                    spec.reverse_tunnel.target
+                    if spec.reverse_tunnel is not None
+                    else None
+                ),
+                tunnel_connect_timeout=(
+                    spec.reverse_tunnel.connect_timeout
+                    if spec.reverse_tunnel is not None
+                    else None
+                ),
+                detached=spec.detached,
+                node_id=spec.node_id,
+                create_timeout=create_timeout,
+            )
+        except Exception as error:
+            raise _convert_error("create sandbox", error) from error
+        return _Session(sandbox, detached=spec.detached)
+
+    def delete_named(self, name: str) -> None:
+        sandbox_id = f"{self.namespace}-{name}"
+        try:
+            yr_sandbox.Sandbox.delete(sandbox_id)
+        except Exception as error:
+            raise _convert_error(f"delete sandbox {name!r}", error) from error
+
+    def close(self) -> None:
+        """The backend has no process-level client to close."""
+
+
+def create_backend(config: BackendConfig) -> Backend:
+    """Construct the HTTP/RRT backend for the lazy registry."""
+
+    return OpenYuanRongSandboxBackend(config)

--- a/sdk/python/akernel_sdk/_backends/openyuanrong_sandbox.py
+++ b/sdk/python/akernel_sdk/_backends/openyuanrong_sandbox.py
@@ -363,6 +363,7 @@ class OpenYuanRongSandboxBackend:
                 ),
                 detached=spec.detached,
                 node_id=spec.node_id,
+                xpu=spec.xpu,
                 create_timeout=create_timeout,
             )
         except Exception as error:

--- a/sdk/python/akernel_sdk/_backends/openyuanrong_sdk.py
+++ b/sdk/python/akernel_sdk/_backends/openyuanrong_sdk.py
@@ -1,0 +1,344 @@
+# Copyright (c) 2026 Ant Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Adapter for the actor-based ``openyuanrong-sdk`` backend."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from .. import _openyuanrong
+from ..types import CommandInfo, CommandResult, EntryInfo, SandboxInfo
+from .base import (
+    Backend,
+    BackendConfig,
+    BackendSession,
+    Capability,
+    SandboxSpec,
+)
+from .errors import BackendOperationError
+from .openyuanrong_sdk_commands import (
+    CommandHandle as NativeCommandHandle,
+)
+from .openyuanrong_sdk_commands import Commands as NativeCommands
+from .openyuanrong_sdk_filesystem import Filesystem as NativeFilesystem
+
+_NAMESPACE = "akernel"
+logger = logging.getLogger(__name__)
+
+
+def _convert_error(operation: str, error: Exception) -> BackendOperationError:
+    return BackendOperationError(f"{operation} failed: {error}")
+
+
+def _rollback_instance(instance: Any, operation: str) -> None:
+    try:
+        _openyuanrong.terminate_instance(instance)
+    except Exception:
+        logger.warning(
+            "failed to roll back an actor after %s failed",
+            operation,
+            exc_info=True,
+        )
+
+
+class _CommandsDriver:
+    def __init__(self, instance: Any) -> None:
+        self._commands = NativeCommands(instance)
+        self._handles: dict[int, NativeCommandHandle] = {}
+
+    def run(
+        self,
+        cmd: str,
+        *,
+        envs: Mapping[str, str] | None,
+        cwd: str | None,
+        timeout: int,
+    ) -> CommandResult:
+        try:
+            result = self._commands.run(
+                cmd,
+                envs=dict(envs) if envs is not None else None,
+                cwd=cwd,
+                timeout=timeout,
+            )
+        except Exception as error:
+            raise _convert_error("command execution", error) from error
+        assert isinstance(result, CommandResult)
+        return result
+
+    def start(
+        self,
+        cmd: str,
+        *,
+        envs: Mapping[str, str] | None,
+        cwd: str | None,
+        stdin: bool,
+    ) -> int:
+        try:
+            handle = self._commands.run(
+                cmd,
+                background=True,
+                envs=dict(envs) if envs is not None else None,
+                cwd=cwd,
+                stdin=stdin,
+            )
+        except Exception as error:
+            raise _convert_error("background command start", error) from error
+        assert isinstance(handle, NativeCommandHandle)
+        self._handles[handle.pid] = handle
+        return handle.pid
+
+    def wait(self, pid: int, timeout: int | None) -> CommandResult:
+        handle = self._handles.get(pid)
+        if handle is None:
+            raise BackendOperationError(f"no command handle for pid {pid}")
+        try:
+            return handle.wait(timeout)
+        except Exception as error:
+            raise _convert_error(f"wait for process {pid}", error) from error
+
+    def kill(self, pid: int) -> bool:
+        try:
+            return self._commands.kill(pid)
+        except Exception as error:
+            raise _convert_error(f"kill process {pid}", error) from error
+
+    def send_stdin(self, pid: int, data: str, eof: bool) -> None:
+        try:
+            self._commands.send_stdin(pid, data, eof)
+        except Exception as error:
+            raise _convert_error(f"send stdin to process {pid}", error) from error
+
+    def list(self) -> list[CommandInfo]:
+        try:
+            return self._commands.list()
+        except Exception as error:
+            raise _convert_error("list processes", error) from error
+
+
+class _FilesystemDriver:
+    def __init__(self, instance: Any, sandbox_id: str) -> None:
+        self._files = NativeFilesystem(instance, instance_id=sandbox_id)
+
+    def read(self, path: str, *, binary: bool) -> str | bytes:
+        try:
+            return self._files.read(path, format="bytes" if binary else "text")
+        except Exception as error:
+            raise _convert_error(f"read {path}", error) from error
+
+    def write(self, path: str, data: str | bytes) -> EntryInfo:
+        try:
+            return self._files.write(path, data)
+        except Exception as error:
+            raise _convert_error(f"write {path}", error) from error
+
+    def list(self, path: str, depth: int) -> list[EntryInfo]:
+        try:
+            return self._files.list(path, depth)
+        except Exception as error:
+            raise _convert_error(f"list {path}", error) from error
+
+    def exists(self, path: str) -> bool:
+        try:
+            return self._files.exists(path)
+        except Exception as error:
+            raise _convert_error(f"check {path}", error) from error
+
+    def remove(self, path: str) -> None:
+        try:
+            self._files.remove(path)
+        except Exception as error:
+            raise _convert_error(f"remove {path}", error) from error
+
+    def rename(self, old_path: str, new_path: str) -> EntryInfo:
+        try:
+            return self._files.rename(old_path, new_path)
+        except Exception as error:
+            raise _convert_error(f"rename {old_path}", error) from error
+
+    def make_dir(self, path: str) -> bool:
+        try:
+            return self._files.make_dir(path)
+        except Exception as error:
+            raise _convert_error(f"create directory {path}", error) from error
+
+    def get_info(self, path: str) -> EntryInfo:
+        try:
+            return self._files.get_info(path)
+        except Exception as error:
+            raise _convert_error(f"get info for {path}", error) from error
+
+    def copy_from_local(self, local_path: str, remote_path: str) -> None:
+        try:
+            self._files.copy_from_local(local_path, remote_path)
+        except FileNotFoundError:
+            raise
+        except Exception as error:
+            raise _convert_error(
+                f"copy {local_path} to {remote_path}", error
+            ) from error
+
+    def copy_to_local(self, remote_path: str, local_path: str) -> None:
+        try:
+            self._files.copy_to_local(remote_path, local_path)
+        except Exception as error:
+            raise _convert_error(
+                f"copy {remote_path} to {local_path}", error
+            ) from error
+
+
+class _Session:
+    def __init__(
+        self,
+        instance: Any,
+        sandbox_id: str,
+        spec: SandboxSpec,
+        tunnel_client: Any,
+    ) -> None:
+        self.id = sandbox_id
+        self.commands = _CommandsDriver(instance)
+        self.files = _FilesystemDriver(instance, sandbox_id)
+        self._instance = instance
+        self._spec = spec
+        self._tunnel_client = tunnel_client
+        self._terminated = False
+        self._closed = False
+
+    def is_running(self) -> bool:
+        if self._terminated:
+            return False
+        return _openyuanrong.ping_instance(self._instance)
+
+    def get_info(self) -> SandboxInfo:
+        try:
+            state = _openyuanrong.instance_state(self._instance)
+        except Exception as error:
+            raise _convert_error("get sandbox info", error) from error
+        return SandboxInfo(
+            id=self.id,
+            state=state,
+            cpu=self._spec.cpu,
+            memory=self._spec.memory,
+            image=self._spec.image,
+        )
+
+    def terminate(self) -> None:
+        if self._terminated:
+            return
+        try:
+            _openyuanrong.terminate_instance(self._instance)
+        except Exception as error:
+            raise _convert_error("terminate sandbox", error) from error
+        finally:
+            self._terminated = True
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._tunnel_client is not None:
+            try:
+                self._tunnel_client.stop()
+            except Exception as error:
+                raise _convert_error("close reverse tunnel", error) from error
+            finally:
+                self._tunnel_client = None
+
+
+class OpenYuanRongSdkBackend:
+    """Actor-based backend implemented by ``openyuanrong-sdk``."""
+
+    name = "openyuanrong-sdk"
+    namespace = _NAMESPACE
+    capabilities = frozenset(Capability)
+
+    def __init__(self, _config: BackendConfig) -> None:
+        _openyuanrong.ensure_initialized()
+
+    def create(self, spec: SandboxSpec) -> BackendSession:
+        options = _openyuanrong.build_options(
+            image=spec.image,
+            rootfs=spec.rootfs,
+            runtime=spec.runtime,
+            cpu=spec.cpu,
+            memory=spec.memory,
+            cpu_limit=spec.cpu_limit,
+            mem_limit=spec.mem_limit,
+            idle_timeout=spec.idle_timeout,
+            schedule_timeout=spec.schedule_timeout,
+            env=spec.env,
+            name=spec.name,
+            port_forwardings=spec.port_forwardings,
+            mounts=spec.mounts,
+            reverse_tunnel=spec.reverse_tunnel,
+            detached=spec.detached,
+            node_id=spec.node_id,
+        )
+        try:
+            instance = _openyuanrong.create_instance(
+                options,
+                cwd=spec.command_cwd,
+            )
+        except Exception as error:
+            raise _convert_error("create sandbox", error) from error
+
+        try:
+            sandbox_id = _openyuanrong.real_instance_id(instance)
+        except Exception as error:
+            _rollback_instance(instance, "physical ID resolution")
+            raise _convert_error("create sandbox", error) from error
+
+        tunnel_client = None
+        try:
+            if spec.reverse_tunnel is not None:
+                tunnel_client = _openyuanrong.start_reverse_tunnel(
+                    instance,
+                    spec.reverse_tunnel,
+                    name=spec.name,
+                )
+        except Exception as error:
+            _rollback_instance(instance, "reverse tunnel startup")
+            raise _convert_error("start reverse tunnel", error) from error
+        try:
+            return _Session(instance, sandbox_id, spec, tunnel_client)
+        except Exception as error:
+            if tunnel_client is not None:
+                try:
+                    tunnel_client.stop()
+                except Exception:
+                    logger.warning(
+                        "failed to close a reverse tunnel after session "
+                        "initialization failed",
+                        exc_info=True,
+                    )
+            _rollback_instance(instance, "session initialization")
+            raise _convert_error("initialize sandbox session", error) from error
+
+    def delete_named(self, name: str) -> None:
+        try:
+            _openyuanrong.delete_named_instance(name)
+        except Exception as error:
+            raise _convert_error(f"delete sandbox {name!r}", error) from error
+
+    def close(self) -> None:
+        _openyuanrong.finalize()
+
+
+def create_backend(config: BackendConfig) -> Backend:
+    """Construct the actor backend for the lazy registry."""
+
+    return OpenYuanRongSdkBackend(config)

--- a/sdk/python/akernel_sdk/_backends/openyuanrong_sdk.py
+++ b/sdk/python/akernel_sdk/_backends/openyuanrong_sdk.py
@@ -287,6 +287,7 @@ class OpenYuanRongSdkBackend:
             reverse_tunnel=spec.reverse_tunnel,
             detached=spec.detached,
             node_id=spec.node_id,
+            xpu=spec.xpu,
         )
         try:
             instance = _openyuanrong.create_instance(

--- a/sdk/python/akernel_sdk/_backends/openyuanrong_sdk_commands.py
+++ b/sdk/python/akernel_sdk/_backends/openyuanrong_sdk_commands.py
@@ -1,0 +1,207 @@
+# Copyright (c) 2026 Ant Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Literal, overload
+
+import yr
+
+from ..types import (
+    YR_GET_DEFAULT_TIMEOUT,
+    YR_GET_TIMEOUT_BUFFER,
+    CommandInfo,
+    CommandResult,
+)
+
+
+class CommandHandle:
+    """Handle for a background process running in the sandbox."""
+
+    def __init__(self, pid: int, instance: Any) -> None:
+        self.pid = pid
+        self._instance = instance
+
+    def wait(self, timeout: int | None = None) -> CommandResult:
+        """Wait for the process to finish and return its captured output.
+
+        Args:
+            timeout: Maximum number of seconds to wait. ``None`` waits without
+                a deadline.
+
+        Returns:
+            The process output and exit code. A timeout is reported with exit
+            code ``-1`` by the sandbox runtime.
+        """
+
+        rpc_timeout = (
+            -1
+            if timeout is None
+            else max(timeout + YR_GET_TIMEOUT_BUFFER, YR_GET_DEFAULT_TIMEOUT)
+        )
+        result = yr.get(
+            self._instance.cmd_wait.invoke(pid=self.pid, timeout=timeout),
+            timeout=rpc_timeout,
+        )
+        return CommandResult(
+            stdout=result["stdout"],
+            stderr=result["stderr"],
+            exit_code=result["exit_code"],
+        )
+
+    def kill(self) -> bool:
+        """Terminate the process and return whether it was found."""
+
+        result = yr.get(self._instance.cmd_kill.invoke(pid=self.pid))
+        return result["killed"]
+
+    def send_stdin(self, data: str, eof: bool = False) -> None:
+        """Write *data* to the process's stdin.
+
+        Args:
+            data: Text to write.
+            eof: Close stdin after writing so the process observes EOF.
+
+        Raises:
+            RuntimeError: The process was not started with stdin enabled or
+                the runtime rejected the write.
+        """
+        result = yr.get(
+            self._instance.cmd_send_stdin.invoke(pid=self.pid, data=data, eof=eof)
+        )
+        if result.get("error"):
+            raise RuntimeError(f"Failed to send stdin: {result['error']}")
+
+    def close_stdin(self) -> None:
+        """Close the process's stdin so it sees EOF."""
+        self.send_stdin("", eof=True)
+
+
+class Commands:
+    """Client-side wrapper for command execution on the remote sandbox."""
+
+    def __init__(self, instance: Any) -> None:
+        self._instance = instance
+
+    @overload
+    def run(
+        self,
+        cmd: str,
+        background: Literal[False] = False,
+        envs: dict[str, str] | None = None,
+        cwd: str | None = None,
+        timeout: int = 60,
+        stdin: Literal[False] = False,
+    ) -> CommandResult: ...
+
+    @overload
+    def run(
+        self,
+        cmd: str,
+        background: Literal[True],
+        envs: dict[str, str] | None = None,
+        cwd: str | None = None,
+        timeout: int = 60,
+        stdin: bool = False,
+    ) -> CommandHandle: ...
+
+    def run(
+        self,
+        cmd: str,
+        background: bool = False,
+        envs: dict[str, str] | None = None,
+        cwd: str | None = None,
+        timeout: int = 60,
+        stdin: bool = False,
+    ) -> CommandResult | CommandHandle:
+        """Execute a command in the sandbox.
+
+        Args:
+            cmd: Shell command to execute.
+            background: Return a process handle without waiting when true.
+            envs: Environment variables for the command.
+            cwd: Working directory for the command.
+            timeout: Maximum foreground execution time in seconds.
+            stdin: Keep stdin open for a background process.
+
+        Returns:
+            A completed result for foreground execution or a process handle
+            for background execution.
+
+        Raises:
+            ValueError: ``stdin`` is requested for foreground execution.
+            RuntimeError: The runtime cannot start a background process.
+        """
+        if stdin and not background:
+            raise ValueError("stdin=True requires background=True")
+
+        if background:
+            result = yr.get(
+                self._instance.cmd_start.invoke(
+                    cmd=cmd, envs=envs, cwd=cwd, want_stdin=stdin
+                )
+            )
+            if result.get("error"):
+                raise RuntimeError(f"Failed to start command: {result['error']}")
+            return CommandHandle(result["pid"], self._instance)
+
+        rpc_timeout = max(timeout + YR_GET_TIMEOUT_BUFFER, YR_GET_DEFAULT_TIMEOUT)
+        result = yr.get(
+            self._instance.cmd_run.invoke(cmd=cmd, envs=envs, cwd=cwd, timeout=timeout),
+            timeout=rpc_timeout,
+        )
+        return CommandResult(
+            stdout=result["stdout"],
+            stderr=result["stderr"],
+            exit_code=result["exit_code"],
+        )
+
+    def list(self) -> list[CommandInfo]:
+        """Return snapshots of processes tracked by this sandbox."""
+
+        result = yr.get(self._instance.cmd_list.invoke())
+        return [
+            CommandInfo(
+                pid=int(process["pid"]),
+                command=str(process["cmd"]),
+                running=bool(process["running"]),
+            )
+            for process in result["processes"]
+        ]
+
+    def kill(self, pid: int) -> bool:
+        """Terminate a tracked process and return whether it was found."""
+
+        result = yr.get(self._instance.cmd_kill.invoke(pid=pid))
+        return result["killed"]
+
+    def send_stdin(self, pid: int, data: str, eof: bool = False) -> None:
+        """Write *data* to the stdin of process *pid*.
+
+        Args:
+            pid: Tracked process ID.
+            data: Text to write.
+            eof: Close stdin after writing so the process observes EOF.
+
+        Raises:
+            RuntimeError: The process was not started with stdin enabled or
+                the runtime rejected the write.
+        """
+        result = yr.get(
+            self._instance.cmd_send_stdin.invoke(pid=pid, data=data, eof=eof)
+        )
+        if result.get("error"):
+            raise RuntimeError(f"Failed to send stdin: {result['error']}")
+
+    def close_stdin(self, pid: int) -> None:
+        """Close the stdin of process *pid* so it sees EOF."""
+        self.send_stdin(pid, "", eof=True)

--- a/sdk/python/akernel_sdk/_backends/openyuanrong_sdk_filesystem.py
+++ b/sdk/python/akernel_sdk/_backends/openyuanrong_sdk_filesystem.py
@@ -1,0 +1,283 @@
+# Copyright (c) 2026 Ant Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import os
+import tempfile
+from collections.abc import Coroutine
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Literal, TypeVar, overload
+
+import yr
+
+from .._addresses import exec_endpoint_from_env
+from ..types import EntryInfo
+
+_T = TypeVar("_T")
+
+
+def _run_coroutine(coroutine: Coroutine[Any, Any, _T]) -> _T:
+    """Run a coroutine from a synchronous API in any caller context."""
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coroutine)
+
+    # asyncio.run() cannot execute in a thread that already owns a running
+    # event loop. Keep Filesystem's public API synchronous and isolate the
+    # underlying async WebSocket helper in a short-lived worker thread.
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(asyncio.run, coroutine).result()
+
+
+class Filesystem:
+    """Client-side wrapper for filesystem operations on the remote sandbox."""
+
+    def __init__(
+        self,
+        instance: Any,
+        instance_id: str | None = None,
+    ) -> None:
+        self._instance = instance
+        self._instance_id = instance_id
+
+    @overload
+    def read(self, path: str, format: Literal["text"] = "text") -> str: ...
+
+    @overload
+    def read(self, path: str, format: Literal["bytes"]) -> bytes: ...
+
+    def read(self, path: str, format: str = "text") -> str | bytes:
+        """Read a file as text or bytes.
+
+        Args:
+            path: Absolute or relative path inside the sandbox.
+            format: Return decoded text or raw bytes.
+
+        Raises:
+            ValueError: ``format`` is not ``"text"`` or ``"bytes"``.
+            RuntimeError: The sandbox cannot read the file.
+        """
+
+        if format not in ("text", "bytes"):
+            raise ValueError("format must be 'text' or 'bytes'")
+        binary = format == "bytes"
+        result = yr.get(self._instance.fs_read.invoke(path=path, binary=binary))
+        if result.get("error"):
+            raise RuntimeError(f"Failed to read {path}: {result['error']}")
+        data = result["data"]
+        if binary:
+            return bytes.fromhex(data)
+        return data
+
+    # Binary data beyond this threshold is routed through copy_from_local
+    # (tar+WebSocket) instead of RPC hex encoding.  Benchmark shows the
+    # crossover at ~16 MB where hex-encoded RPC starts to degrade while
+    # copy_from_local's fixed connection overhead is amortized.
+    _WRITE_SIZE_THRESHOLD = 16 * 1024 * 1024
+
+    def write(self, path: str, data: str | bytes) -> EntryInfo:
+        """Write text or bytes and return metadata for the remote file."""
+
+        if isinstance(data, bytes):
+            if len(data) >= self._WRITE_SIZE_THRESHOLD:
+                return self._write_via_copy(path, data)
+            binary = True
+            send_data = data.hex()
+        else:
+            binary = False
+            send_data = data
+        result = yr.get(
+            self._instance.fs_write.invoke(path=path, data=send_data, binary=binary)
+        )
+        if result.get("error"):
+            raise RuntimeError(f"Failed to write {path}: {result['error']}")
+        return EntryInfo(
+            name=result["name"],
+            path=result["path"],
+            type=result["type"],
+            size=result["size"],
+            permissions="",
+            modified_time=0.0,
+        )
+
+    def _write_via_copy(self, remote_path: str, data: bytes) -> EntryInfo:
+        """Write large binary data via copy_from_local to avoid hex bloat."""
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        try:
+            tmp.write(data)
+            tmp.close()
+            self.copy_from_local(tmp.name, remote_path)
+        finally:
+            os.unlink(tmp.name)
+        return EntryInfo(
+            name=os.path.basename(remote_path),
+            path=remote_path,
+            type="file",
+            size=len(data),
+            permissions="",
+            modified_time=0.0,
+        )
+
+    def list(self, path: str, depth: int = 1) -> list[EntryInfo]:
+        """List entries below a sandbox path up to ``depth`` levels."""
+
+        result = yr.get(self._instance.fs_list.invoke(path=path, depth=depth))
+        if result.get("error"):
+            raise RuntimeError(f"Failed to list {path}: {result['error']}")
+        return [
+            EntryInfo(
+                name=e["name"],
+                path=e["path"],
+                type=e["type"],
+                size=e["size"],
+                permissions=e["permissions"],
+                modified_time=e["modified_time"],
+            )
+            for e in result["entries"]
+        ]
+
+    def exists(self, path: str) -> bool:
+        """Return whether a sandbox path exists."""
+
+        result = yr.get(self._instance.fs_exists.invoke(path=path))
+        return result["exists"]
+
+    def _get_connection(self) -> tuple[str, str, str, str, bool]:
+        # File copy is implemented by the frontend exec WebSocket
+        # (/terminal/ws).  By default it follows AKERNEL_SERVER_ADDRESS and
+        # uses TLS; standalone or custom topologies can override it with
+        # AKERNEL_GATEWAY_ADDRESS/YR_GATEWAY_ADDRESS.
+        endpoint = exec_endpoint_from_env()
+        instance_id = self._instance_id
+        if not instance_id:
+            raise RuntimeError("Instance ID is not set.")
+        from yr.config_manager import ConfigManager
+
+        token = ConfigManager().auth_token
+        return endpoint.host, str(endpoint.port), instance_id, token, endpoint.use_tls
+
+    def _cp(self, src: str, dst: str, upload: bool) -> None:
+        from yr.cli.exec import (
+            CopyRequest,
+            ExecConnection,
+            choose_cp_mode,
+            copy_from_remote,
+            copy_from_remote_streaming,
+            copy_to_remote,
+            copy_to_remote_streaming,
+        )
+
+        host, port, instance_id, token, use_ssl = self._get_connection()
+        local_path = src if upload else dst
+        remote_path = dst if upload else src
+
+        if upload and not os.path.exists(local_path):
+            raise FileNotFoundError(f"Local source path not found: {local_path}")
+
+        streaming = choose_cp_mode(local_path, remote_path, upload=upload)
+        conn = ExecConnection(
+            host=host,
+            port=port,
+            use_ssl=use_ssl,
+            verify_server=False,
+            token=token,
+        )
+        request = CopyRequest(
+            instance=instance_id,
+            local_path=local_path,
+            remote_path=remote_path,
+        )
+
+        if upload:
+            fn = copy_to_remote_streaming if streaming else copy_to_remote
+        else:
+            fn = copy_from_remote_streaming if streaming else copy_from_remote
+
+        _run_coroutine(fn(conn, request))
+
+    def copy_from_local(self, local_path: str, remote_path: str) -> None:
+        """Copy a local file or directory **into** the sandbox.
+
+        Args:
+            local_path: Absolute or relative path on the **local** machine.
+            remote_path: Absolute path inside the **sandbox**.
+
+        Raises:
+            FileNotFoundError: *local_path* does not exist.
+            RuntimeError: Server address is not configured.
+        """
+        self._cp(local_path, remote_path, upload=True)
+
+    def copy_to_local(self, remote_path: str, local_path: str) -> None:
+        """Copy a file or directory **from** the sandbox to the local machine.
+
+        Args:
+            remote_path: Absolute path inside the **sandbox**.
+            local_path: Absolute or relative path on the **local** machine.
+
+        Raises:
+            RuntimeError: Server address is not configured.
+        """
+        self._cp(remote_path, local_path, upload=False)
+
+    def remove(self, path: str) -> None:
+        """Remove a file or directory from the sandbox."""
+
+        result = yr.get(self._instance.fs_remove.invoke(path=path))
+        if result.get("error"):
+            raise RuntimeError(f"Failed to remove {path}: {result['error']}")
+
+    def rename(self, old_path: str, new_path: str) -> EntryInfo:
+        """Rename a sandbox path and return its updated metadata."""
+
+        result = yr.get(
+            self._instance.fs_rename.invoke(old_path=old_path, new_path=new_path)
+        )
+        if result.get("error"):
+            raise RuntimeError(
+                f"Failed to rename {old_path} -> {new_path}: {result['error']}"
+            )
+        return EntryInfo(
+            name=result["name"],
+            path=result["path"],
+            type=result["type"],
+            size=result["size"],
+            permissions=result["permissions"],
+            modified_time=result["modified_time"],
+        )
+
+    def make_dir(self, path: str) -> bool:
+        """Create a directory and return whether it was newly created."""
+
+        result = yr.get(self._instance.fs_make_dir.invoke(path=path))
+        if result.get("error"):
+            raise RuntimeError(f"Failed to make dir {path}: {result['error']}")
+        return result["created"]
+
+    def get_info(self, path: str) -> EntryInfo:
+        """Return metadata for a sandbox path."""
+
+        result = yr.get(self._instance.fs_get_info.invoke(path=path))
+        if result.get("error"):
+            raise RuntimeError(f"Failed to get info for {path}: {result['error']}")
+        return EntryInfo(
+            name=result["name"],
+            path=result["path"],
+            type=result["type"],
+            size=result["size"],
+            permissions=result["permissions"],
+            modified_time=result["modified_time"],
+        )

--- a/sdk/python/akernel_sdk/_backends/registry.py
+++ b/sdk/python/akernel_sdk/_backends/registry.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 Ant Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Import-time backend selection and lazy backend loading."""
+
+from __future__ import annotations
+
+import atexit
+import importlib
+import os
+import threading
+from importlib import metadata
+from typing import Final
+
+from .._addresses import api_endpoint_from_env, gateway_endpoint_from_env
+from .base import Backend, BackendConfig
+from .errors import BackendNotInstalledError, InvalidBackendError
+
+OPENYUANRONG_SANDBOX: Final = "openyuanrong-sandbox"
+OPENYUANRONG_SDK: Final = "openyuanrong-sdk"
+SUPPORTED_BACKENDS: Final = (OPENYUANRONG_SANDBOX, OPENYUANRONG_SDK)
+
+_MODULES: Final = {
+    OPENYUANRONG_SANDBOX: "akernel_sdk._backends.openyuanrong_sandbox",
+    OPENYUANRONG_SDK: "akernel_sdk._backends.openyuanrong_sdk",
+}
+
+
+def _is_installed(distribution: str) -> bool:
+    try:
+        metadata.version(distribution)
+    except metadata.PackageNotFoundError:
+        return False
+    return True
+
+
+def _select_backend() -> str | None:
+    configured = os.environ.get("AKERNEL_BACKEND", "").strip()
+    if configured:
+        if configured not in SUPPORTED_BACKENDS:
+            choices = ", ".join(SUPPORTED_BACKENDS)
+            raise InvalidBackendError(
+                f"unsupported AKERNEL_BACKEND {configured!r}; expected one of: "
+                f"{choices}"
+            )
+        return configured
+    for candidate in SUPPORTED_BACKENDS:
+        if _is_installed(candidate):
+            return candidate
+    return None
+
+
+_selected_backend = _select_backend()
+_loaded_backend: Backend | None = None
+_load_lock = threading.Lock()
+
+
+def selected_backend() -> str | None:
+    """Return the backend identifier selected when this module was imported."""
+
+    return _selected_backend
+
+
+def _not_installed_error(backend: str | None) -> BackendNotInstalledError:
+    if backend is None:
+        return BackendNotInstalledError(
+            "The default AKernel backend is not installed. Reinstall with:\n"
+            "  pip install akernel-sdk\n"
+            "The actor backend is also available with:\n"
+            "  pip install 'akernel-sdk[openyuanrong-sdk]'"
+        )
+    if backend == OPENYUANRONG_SANDBOX:
+        command = "pip install akernel-sdk"
+    else:
+        command = f"pip install 'akernel-sdk[{backend}]'"
+    return BackendNotInstalledError(
+        f"Backend {backend!r} is not installed. Install it with:\n"
+        f"  {command}"
+    )
+
+
+def _config_from_env() -> BackendConfig:
+    token = os.environ.get("AKERNEL_TOKEN", "").strip()
+    if not token:
+        raise RuntimeError("AKERNEL_TOKEN is not set")
+    return BackendConfig(
+        api_endpoint=api_endpoint_from_env(),
+        gateway_endpoint=gateway_endpoint_from_env(),
+        token=token,
+    )
+
+
+def load_backend() -> Backend:
+    """Load and construct the selected backend once."""
+
+    global _loaded_backend
+    if _loaded_backend is not None:
+        return _loaded_backend
+
+    with _load_lock:
+        if _loaded_backend is not None:
+            return _loaded_backend
+        backend_name = _selected_backend
+        if backend_name is None or not _is_installed(backend_name):
+            raise _not_installed_error(backend_name)
+        module = importlib.import_module(_MODULES[backend_name])
+        backend = module.create_backend(_config_from_env())
+        _loaded_backend = backend
+        atexit.register(backend.close)
+        return backend

--- a/sdk/python/akernel_sdk/_openyuanrong.py
+++ b/sdk/python/akernel_sdk/_openyuanrong.py
@@ -146,6 +146,7 @@ def build_options(
     reverse_tunnel: HttpReverseTunnel | None,
     detached: bool,
     node_id: str | None,
+    xpu: str | None,
 ) -> Any:
     """Translate the stable SDK configuration to openYuanrong options."""
 
@@ -188,6 +189,11 @@ def build_options(
         options.custom_extensions["mounts"] = json.dumps(
             [mount.to_dict() for mount in mounts]
         )
+    if xpu is not None:
+        xpu_type, model, count_text = xpu.split(":")
+        options.custom_resources[
+            f"{xpu_type.upper()}/{model or '.+'}/count"
+        ] = float(count_text)
 
     forwarded = list(port_forwardings)
     if reverse_tunnel is not None:

--- a/sdk/python/akernel_sdk/_openyuanrong.py
+++ b/sdk/python/akernel_sdk/_openyuanrong.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import atexit
 import json
 import logging
 import os
@@ -74,8 +73,17 @@ def ensure_initialized() -> None:
                 bypass_datasystem=True,
             )
         )
-        atexit.register(yr.finalize)
         _initialized = True
+
+
+def finalize() -> None:
+    """Release process-level openYuanrong SDK resources."""
+
+    global _initialized
+    if not _initialized:
+        return
+    yr.finalize()
+    _initialized = False
 
 
 def _validate_positive_int(name: str, value: int, *, allow_zero: bool = False) -> None:
@@ -213,7 +221,17 @@ def build_options(
 def create_instance(options: Any, *, cwd: str | None) -> Any:
     instance_class: Any = _SandboxInstance
     handle = instance_class.options(options).invoke(cwd=cwd)
-    yr.get(handle.ping.invoke())
+    try:
+        yr.get(handle.ping.invoke())
+    except Exception:
+        try:
+            terminate_instance(handle)
+        except Exception:
+            logger.warning(
+                "failed to roll back an actor after its readiness check failed",
+                exc_info=True,
+            )
+        raise
     return handle
 
 

--- a/sdk/python/akernel_sdk/_resources.py
+++ b/sdk/python/akernel_sdk/_resources.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026 Ant Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backend-neutral resource discovery through the frontend API."""
+
+import json
+import os
+from collections.abc import Mapping
+from urllib import request
+from urllib.error import HTTPError, URLError
+
+from ._addresses import api_endpoint_from_env
+from .cli import _create_ssl_context, _extract_labels, _extract_resources
+from .types import NodeInfo
+
+
+def resources() -> list[NodeInfo]:
+    """Return cluster resources through stable AKernel value types."""
+
+    endpoint = api_endpoint_from_env()
+    token = os.environ.get("AKERNEL_TOKEN", "").strip()
+    if not token:
+        raise RuntimeError("AKERNEL_TOKEN is not set")
+    req = request.Request(
+        f"{endpoint.base_url()}/global-scheduler/resources",
+        method="GET",
+        headers={"X-Auth": token, "Type": "json", "Accept": "application/json"},
+    )
+    try:
+        with request.urlopen(req, context=_create_ssl_context()) as response:
+            body = response.read().decode("utf-8")
+    except HTTPError as error:
+        body = error.read().decode("utf-8")
+        raise RuntimeError(
+            f"resource query failed: HTTP {error.code} {body}"
+        ) from error
+    except URLError as error:
+        raise RuntimeError(f"resource query failed: {error}") from error
+
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as error:
+        raise RuntimeError("resource query returned invalid JSON") from error
+    resource = payload.get("resource") if isinstance(payload, Mapping) else None
+    if not isinstance(resource, Mapping):
+        return []
+    fragments = resource.get("fragment")
+    if not isinstance(fragments, Mapping):
+        fragments = {str(resource.get("id", "")): resource}
+
+    result = []
+    for node_id, value in fragments.items():
+        if not isinstance(value, dict):
+            continue
+        result.append(
+            NodeInfo(
+                id=str(value.get("id") or node_id),
+                status=int(value.get("status", 0)),
+                capacity=_extract_resources(value.get("capacity", {})),
+                allocatable=_extract_resources(value.get("allocatable", {})),
+                labels=_extract_labels(value.get("nodeLabels", {})),
+            )
+        )
+    return result

--- a/sdk/python/akernel_sdk/commands.py
+++ b/sdk/python/akernel_sdk/commands.py
@@ -12,85 +12,49 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Literal, overload
+"""Backend-neutral command facade."""
 
-import yr
+from __future__ import annotations
 
-from .types import (
-    YR_GET_DEFAULT_TIMEOUT,
-    YR_GET_TIMEOUT_BUFFER,
-    CommandInfo,
-    CommandResult,
-)
+from typing import Literal, overload
+
+from ._backends.base import CommandsDriver
+from .types import CommandInfo, CommandResult
 
 
 class CommandHandle:
     """Handle for a background process running in the sandbox."""
 
-    def __init__(self, pid: int, instance: Any) -> None:
+    def __init__(self, pid: int, driver: CommandsDriver) -> None:
         self.pid = pid
-        self._instance = instance
+        self._driver = driver
 
     def wait(self, timeout: int | None = None) -> CommandResult:
-        """Wait for the process to finish and return its captured output.
+        """Wait for the process to finish and return its captured output."""
 
-        Args:
-            timeout: Maximum number of seconds to wait. ``None`` waits without
-                a deadline.
-
-        Returns:
-            The process output and exit code. A timeout is reported with exit
-            code ``-1`` by the sandbox runtime.
-        """
-
-        rpc_timeout = (
-            -1
-            if timeout is None
-            else max(timeout + YR_GET_TIMEOUT_BUFFER, YR_GET_DEFAULT_TIMEOUT)
-        )
-        result = yr.get(
-            self._instance.cmd_wait.invoke(pid=self.pid, timeout=timeout),
-            timeout=rpc_timeout,
-        )
-        return CommandResult(
-            stdout=result["stdout"],
-            stderr=result["stderr"],
-            exit_code=result["exit_code"],
-        )
+        return self._driver.wait(self.pid, timeout)
 
     def kill(self) -> bool:
         """Terminate the process and return whether it was found."""
 
-        result = yr.get(self._instance.cmd_kill.invoke(pid=self.pid))
-        return result["killed"]
+        return self._driver.kill(self.pid)
 
     def send_stdin(self, data: str, eof: bool = False) -> None:
-        """Write *data* to the process's stdin.
+        """Write text to the process's stdin."""
 
-        Args:
-            data: Text to write.
-            eof: Close stdin after writing so the process observes EOF.
-
-        Raises:
-            RuntimeError: The process was not started with stdin enabled or
-                the runtime rejected the write.
-        """
-        result = yr.get(
-            self._instance.cmd_send_stdin.invoke(pid=self.pid, data=data, eof=eof)
-        )
-        if result.get("error"):
-            raise RuntimeError(f"Failed to send stdin: {result['error']}")
+        self._driver.send_stdin(self.pid, data, eof)
 
     def close_stdin(self) -> None:
-        """Close the process's stdin so it sees EOF."""
+        """Close the process's stdin so it observes EOF."""
+
         self.send_stdin("", eof=True)
 
 
 class Commands:
     """Client-side wrapper for command execution on the remote sandbox."""
 
-    def __init__(self, instance: Any) -> None:
-        self._instance = instance
+    def __init__(self, driver: CommandsDriver) -> None:
+        self._driver = driver
 
     @overload
     def run(
@@ -123,85 +87,36 @@ class Commands:
         timeout: int = 60,
         stdin: bool = False,
     ) -> CommandResult | CommandHandle:
-        """Execute a command in the sandbox.
+        """Execute a foreground command or start a background process."""
 
-        Args:
-            cmd: Shell command to execute.
-            background: Return a process handle without waiting when true.
-            envs: Environment variables for the command.
-            cwd: Working directory for the command.
-            timeout: Maximum foreground execution time in seconds.
-            stdin: Keep stdin open for a background process.
-
-        Returns:
-            A completed result for foreground execution or a process handle
-            for background execution.
-
-        Raises:
-            ValueError: ``stdin`` is requested for foreground execution.
-            RuntimeError: The runtime cannot start a background process.
-        """
         if stdin and not background:
             raise ValueError("stdin=True requires background=True")
-
         if background:
-            result = yr.get(
-                self._instance.cmd_start.invoke(
-                    cmd=cmd, envs=envs, cwd=cwd, want_stdin=stdin
-                )
+            pid = self._driver.start(
+                cmd,
+                envs=envs,
+                cwd=cwd,
+                stdin=stdin,
             )
-            if result.get("error"):
-                raise RuntimeError(f"Failed to start command: {result['error']}")
-            return CommandHandle(result["pid"], self._instance)
-
-        rpc_timeout = max(timeout + YR_GET_TIMEOUT_BUFFER, YR_GET_DEFAULT_TIMEOUT)
-        result = yr.get(
-            self._instance.cmd_run.invoke(cmd=cmd, envs=envs, cwd=cwd, timeout=timeout),
-            timeout=rpc_timeout,
-        )
-        return CommandResult(
-            stdout=result["stdout"],
-            stderr=result["stderr"],
-            exit_code=result["exit_code"],
-        )
+            return CommandHandle(pid, self._driver)
+        return self._driver.run(cmd, envs=envs, cwd=cwd, timeout=timeout)
 
     def list(self) -> list[CommandInfo]:
         """Return snapshots of processes tracked by this sandbox."""
 
-        result = yr.get(self._instance.cmd_list.invoke())
-        return [
-            CommandInfo(
-                pid=int(process["pid"]),
-                command=str(process["cmd"]),
-                running=bool(process["running"]),
-            )
-            for process in result["processes"]
-        ]
+        return self._driver.list()
 
     def kill(self, pid: int) -> bool:
         """Terminate a tracked process and return whether it was found."""
 
-        result = yr.get(self._instance.cmd_kill.invoke(pid=pid))
-        return result["killed"]
+        return self._driver.kill(pid)
 
     def send_stdin(self, pid: int, data: str, eof: bool = False) -> None:
-        """Write *data* to the stdin of process *pid*.
+        """Write text to the stdin of a tracked process."""
 
-        Args:
-            pid: Tracked process ID.
-            data: Text to write.
-            eof: Close stdin after writing so the process observes EOF.
-
-        Raises:
-            RuntimeError: The process was not started with stdin enabled or
-                the runtime rejected the write.
-        """
-        result = yr.get(
-            self._instance.cmd_send_stdin.invoke(pid=pid, data=data, eof=eof)
-        )
-        if result.get("error"):
-            raise RuntimeError(f"Failed to send stdin: {result['error']}")
+        self._driver.send_stdin(pid, data, eof)
 
     def close_stdin(self, pid: int) -> None:
-        """Close the stdin of process *pid* so it sees EOF."""
+        """Close the stdin of a tracked process."""
+
         self.send_stdin(pid, "", eof=True)

--- a/sdk/python/akernel_sdk/filesystem.py
+++ b/sdk/python/akernel_sdk/filesystem.py
@@ -12,46 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
-import os
-import tempfile
-from collections.abc import Coroutine
-from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Literal, TypeVar, overload
+"""Backend-neutral filesystem facade."""
 
-import yr
+from __future__ import annotations
 
-from ._addresses import exec_endpoint_from_env
+from typing import Literal, overload
+
+from ._backends.base import FilesystemDriver
 from .types import EntryInfo
-
-_T = TypeVar("_T")
-
-
-def _run_coroutine(coroutine: Coroutine[Any, Any, _T]) -> _T:
-    """Run a coroutine from a synchronous API in any caller context."""
-
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(coroutine)
-
-    # asyncio.run() cannot execute in a thread that already owns a running
-    # event loop. Keep Filesystem's public API synchronous and isolate the
-    # underlying async WebSocket helper in a short-lived worker thread.
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        return executor.submit(asyncio.run, coroutine).result()
 
 
 class Filesystem:
-    """Client-side wrapper for filesystem operations on the remote sandbox."""
+    """Filesystem operations for one remote sandbox."""
 
-    def __init__(
-        self,
-        instance: Any,
-        instance_id: str | None = None,
-    ) -> None:
-        self._instance = instance
-        self._instance_id = instance_id
+    def __init__(self, driver: FilesystemDriver) -> None:
+        self._driver = driver
 
     @overload
     def read(self, path: str, format: Literal["text"] = "text") -> str: ...
@@ -60,224 +35,53 @@ class Filesystem:
     def read(self, path: str, format: Literal["bytes"]) -> bytes: ...
 
     def read(self, path: str, format: str = "text") -> str | bytes:
-        """Read a file as text or bytes.
-
-        Args:
-            path: Absolute or relative path inside the sandbox.
-            format: Return decoded text or raw bytes.
-
-        Raises:
-            ValueError: ``format`` is not ``"text"`` or ``"bytes"``.
-            RuntimeError: The sandbox cannot read the file.
-        """
+        """Read a file as text or bytes."""
 
         if format not in ("text", "bytes"):
             raise ValueError("format must be 'text' or 'bytes'")
-        binary = format == "bytes"
-        result = yr.get(self._instance.fs_read.invoke(path=path, binary=binary))
-        if result.get("error"):
-            raise RuntimeError(f"Failed to read {path}: {result['error']}")
-        data = result["data"]
-        if binary:
-            return bytes.fromhex(data)
-        return data
-
-    # Binary data beyond this threshold is routed through copy_from_local
-    # (tar+WebSocket) instead of RPC hex encoding.  Benchmark shows the
-    # crossover at ~16 MB where hex-encoded RPC starts to degrade while
-    # copy_from_local's fixed connection overhead is amortized.
-    _WRITE_SIZE_THRESHOLD = 16 * 1024 * 1024
+        return self._driver.read(path, binary=format == "bytes")
 
     def write(self, path: str, data: str | bytes) -> EntryInfo:
-        """Write text or bytes and return metadata for the remote file."""
+        """Write text or bytes and return remote metadata."""
 
-        if isinstance(data, bytes):
-            if len(data) >= self._WRITE_SIZE_THRESHOLD:
-                return self._write_via_copy(path, data)
-            binary = True
-            send_data = data.hex()
-        else:
-            binary = False
-            send_data = data
-        result = yr.get(
-            self._instance.fs_write.invoke(path=path, data=send_data, binary=binary)
-        )
-        if result.get("error"):
-            raise RuntimeError(f"Failed to write {path}: {result['error']}")
-        return EntryInfo(
-            name=result["name"],
-            path=result["path"],
-            type=result["type"],
-            size=result["size"],
-            permissions="",
-            modified_time=0.0,
-        )
-
-    def _write_via_copy(self, remote_path: str, data: bytes) -> EntryInfo:
-        """Write large binary data via copy_from_local to avoid hex bloat."""
-        tmp = tempfile.NamedTemporaryFile(delete=False)
-        try:
-            tmp.write(data)
-            tmp.close()
-            self.copy_from_local(tmp.name, remote_path)
-        finally:
-            os.unlink(tmp.name)
-        return EntryInfo(
-            name=os.path.basename(remote_path),
-            path=remote_path,
-            type="file",
-            size=len(data),
-            permissions="",
-            modified_time=0.0,
-        )
+        return self._driver.write(path, data)
 
     def list(self, path: str, depth: int = 1) -> list[EntryInfo]:
-        """List entries below a sandbox path up to ``depth`` levels."""
+        """List entries below a path."""
 
-        result = yr.get(self._instance.fs_list.invoke(path=path, depth=depth))
-        if result.get("error"):
-            raise RuntimeError(f"Failed to list {path}: {result['error']}")
-        return [
-            EntryInfo(
-                name=e["name"],
-                path=e["path"],
-                type=e["type"],
-                size=e["size"],
-                permissions=e["permissions"],
-                modified_time=e["modified_time"],
-            )
-            for e in result["entries"]
-        ]
+        return self._driver.list(path, depth)
 
     def exists(self, path: str) -> bool:
-        """Return whether a sandbox path exists."""
+        """Return whether a path exists."""
 
-        result = yr.get(self._instance.fs_exists.invoke(path=path))
-        return result["exists"]
-
-    def _get_connection(self) -> tuple[str, str, str, str, bool]:
-        # File copy is implemented by the frontend exec WebSocket
-        # (/terminal/ws).  By default it follows AKERNEL_SERVER_ADDRESS and
-        # uses TLS; standalone or custom topologies can override it with
-        # AKERNEL_GATEWAY_ADDRESS/YR_GATEWAY_ADDRESS.
-        endpoint = exec_endpoint_from_env()
-        instance_id = self._instance_id
-        if not instance_id:
-            raise RuntimeError("Instance ID is not set.")
-        from yr.config_manager import ConfigManager
-
-        token = ConfigManager().auth_token
-        return endpoint.host, str(endpoint.port), instance_id, token, endpoint.use_tls
-
-    def _cp(self, src: str, dst: str, upload: bool) -> None:
-        from yr.cli.exec import (
-            CopyRequest,
-            ExecConnection,
-            choose_cp_mode,
-            copy_from_remote,
-            copy_from_remote_streaming,
-            copy_to_remote,
-            copy_to_remote_streaming,
-        )
-
-        host, port, instance_id, token, use_ssl = self._get_connection()
-        local_path = src if upload else dst
-        remote_path = dst if upload else src
-
-        if upload and not os.path.exists(local_path):
-            raise FileNotFoundError(f"Local source path not found: {local_path}")
-
-        streaming = choose_cp_mode(local_path, remote_path, upload=upload)
-        conn = ExecConnection(
-            host=host,
-            port=port,
-            use_ssl=use_ssl,
-            verify_server=False,
-            token=token,
-        )
-        request = CopyRequest(
-            instance=instance_id,
-            local_path=local_path,
-            remote_path=remote_path,
-        )
-
-        if upload:
-            fn = copy_to_remote_streaming if streaming else copy_to_remote
-        else:
-            fn = copy_from_remote_streaming if streaming else copy_from_remote
-
-        _run_coroutine(fn(conn, request))
-
-    def copy_from_local(self, local_path: str, remote_path: str) -> None:
-        """Copy a local file or directory **into** the sandbox.
-
-        Args:
-            local_path: Absolute or relative path on the **local** machine.
-            remote_path: Absolute path inside the **sandbox**.
-
-        Raises:
-            FileNotFoundError: *local_path* does not exist.
-            RuntimeError: Server address is not configured.
-        """
-        self._cp(local_path, remote_path, upload=True)
-
-    def copy_to_local(self, remote_path: str, local_path: str) -> None:
-        """Copy a file or directory **from** the sandbox to the local machine.
-
-        Args:
-            remote_path: Absolute path inside the **sandbox**.
-            local_path: Absolute or relative path on the **local** machine.
-
-        Raises:
-            RuntimeError: Server address is not configured.
-        """
-        self._cp(remote_path, local_path, upload=False)
+        return self._driver.exists(path)
 
     def remove(self, path: str) -> None:
-        """Remove a file or directory from the sandbox."""
+        """Remove a file or directory."""
 
-        result = yr.get(self._instance.fs_remove.invoke(path=path))
-        if result.get("error"):
-            raise RuntimeError(f"Failed to remove {path}: {result['error']}")
+        self._driver.remove(path)
 
     def rename(self, old_path: str, new_path: str) -> EntryInfo:
-        """Rename a sandbox path and return its updated metadata."""
+        """Rename a remote path."""
 
-        result = yr.get(
-            self._instance.fs_rename.invoke(old_path=old_path, new_path=new_path)
-        )
-        if result.get("error"):
-            raise RuntimeError(
-                f"Failed to rename {old_path} -> {new_path}: {result['error']}"
-            )
-        return EntryInfo(
-            name=result["name"],
-            path=result["path"],
-            type=result["type"],
-            size=result["size"],
-            permissions=result["permissions"],
-            modified_time=result["modified_time"],
-        )
+        return self._driver.rename(old_path, new_path)
 
     def make_dir(self, path: str) -> bool:
-        """Create a directory and return whether it was newly created."""
+        """Create a directory and report whether it was newly created."""
 
-        result = yr.get(self._instance.fs_make_dir.invoke(path=path))
-        if result.get("error"):
-            raise RuntimeError(f"Failed to make dir {path}: {result['error']}")
-        return result["created"]
+        return self._driver.make_dir(path)
 
     def get_info(self, path: str) -> EntryInfo:
-        """Return metadata for a sandbox path."""
+        """Return metadata for a remote path."""
 
-        result = yr.get(self._instance.fs_get_info.invoke(path=path))
-        if result.get("error"):
-            raise RuntimeError(f"Failed to get info for {path}: {result['error']}")
-        return EntryInfo(
-            name=result["name"],
-            path=result["path"],
-            type=result["type"],
-            size=result["size"],
-            permissions=result["permissions"],
-            modified_time=result["modified_time"],
-        )
+        return self._driver.get_info(path)
+
+    def copy_from_local(self, local_path: str, remote_path: str) -> None:
+        """Copy a local file or directory into the sandbox."""
+
+        self._driver.copy_from_local(local_path, remote_path)
+
+    def copy_to_local(self, remote_path: str, local_path: str) -> None:
+        """Copy a sandbox file or directory to the local machine."""
+
+        self._driver.copy_to_local(remote_path, local_path)

--- a/sdk/python/akernel_sdk/sandbox.py
+++ b/sdk/python/akernel_sdk/sandbox.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import ssl
 import urllib.request
 from collections.abc import Mapping, Sequence
@@ -33,6 +34,7 @@ from .pty import Pty
 from .types import HttpReverseTunnel, Mount, S3Config, SandboxInfo
 
 _SUPPORTED_RUNTIMES = ("runsc", "kata")
+_SUPPORTED_XPU_TYPES = frozenset({"gpu"})
 _traefik_internal_ip_cache: str | None = None
 logger = logging.getLogger(__name__)
 
@@ -78,6 +80,26 @@ def _validate_integer(
         raise TypeError(f"{name} must be an integer")
     if value < minimum:
         raise ValueError(f"{name} must be greater than or equal to {minimum}")
+
+
+def _validate_xpu(xpu: str | None) -> None:
+    if xpu is None:
+        return
+    if not isinstance(xpu, str):
+        raise TypeError("xpu must be a string or None")
+
+    fields = xpu.split(":")
+    if len(fields) != 3 or not fields[0] or not fields[2]:
+        raise ValueError("xpu must have exactly three fields: type:model:count")
+    if any(field != field.strip() for field in fields):
+        raise ValueError("xpu fields must not contain surrounding whitespace")
+
+    xpu_type, _, count_text = fields
+    xpu_type = xpu_type.lower()
+    if xpu_type not in _SUPPORTED_XPU_TYPES:
+        raise ValueError(f"unsupported xpu type: {xpu_type}")
+    if re.fullmatch(r"[0-9]+", count_text) is None or int(count_text) <= 0:
+        raise ValueError("xpu count must be a positive integer")
 
 
 def _get_traefik_internal_ip(gateway: Endpoint) -> tuple[str, int]:
@@ -130,6 +152,8 @@ class Sandbox:
         reverse_tunnel: HttpReverseTunnel | None = None,
         detached: bool = False,
         node_id: str | None = None,
+        *,
+        xpu: str | None = None,
     ) -> None:
         """Create and wait for a sandbox to become ready.
 
@@ -152,6 +176,9 @@ class Sandbox:
             reverse_tunnel: SDK-side HTTP service exposed inside the sandbox.
             detached: Keep the sandbox alive when this client closes.
             node_id: Require placement on a specific AKernel node.
+            xpu: Optional whole-device XPU request in ``type:model:count``
+                format. Leave ``model`` empty to accept any model. Currently
+                only ``gpu`` is supported.
 
         Raises:
             TypeError: An argument has an invalid type.
@@ -201,6 +228,7 @@ class Sandbox:
                 raise TypeError("node_id must be a string")
             if not node_id.strip():
                 raise ValueError("node_id must be a non-empty string")
+        _validate_xpu(xpu)
         if reverse_tunnel is not None and not isinstance(
             reverse_tunnel, HttpReverseTunnel
         ):
@@ -248,6 +276,7 @@ class Sandbox:
             reverse_tunnel=reverse_tunnel,
             detached=detached,
             node_id=node_id,
+            xpu=xpu,
         )
         self._session = load_backend().create(spec)
         try:

--- a/sdk/python/akernel_sdk/sandbox.py
+++ b/sdk/python/akernel_sdk/sandbox.py
@@ -17,13 +17,16 @@
 from __future__ import annotations
 
 import json
+import logging
 import ssl
 import urllib.request
 from collections.abc import Mapping, Sequence
-from typing import Any
+from types import MappingProxyType
+from typing import Literal, cast
 
-from . import _openyuanrong
 from ._addresses import Endpoint, api_endpoint_from_env, gateway_endpoint_from_env
+from ._backends.base import BackendSession, SandboxSpec
+from ._backends.registry import load_backend
 from .commands import Commands
 from .filesystem import Filesystem
 from .pty import Pty
@@ -31,6 +34,7 @@ from .types import HttpReverseTunnel, Mount, S3Config, SandboxInfo
 
 _SUPPORTED_RUNTIMES = ("runsc", "kata")
 _traefik_internal_ip_cache: str | None = None
+logger = logging.getLogger(__name__)
 
 
 def _validate_port(name: str, port: int) -> None:
@@ -62,6 +66,18 @@ def _normalize_mounts(mounts: Sequence[Mount] | None) -> list[Mount]:
     if not all(isinstance(mount, Mount) for mount in result):
         raise TypeError("mounts must contain only Mount objects")
     return result
+
+
+def _validate_integer(
+    name: str,
+    value: int,
+    *,
+    minimum: int,
+) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an integer")
+    if value < minimum:
+        raise ValueError(f"{name} must be greater than or equal to {minimum}")
 
 
 def _get_traefik_internal_ip(gateway: Endpoint) -> tuple[str, int]:
@@ -154,6 +170,17 @@ class Sandbox:
                 f"unsupported runtime {runtime!r}; "
                 f"supported runtimes: {', '.join(_SUPPORTED_RUNTIMES)}"
             )
+        _validate_integer("cpu", cpu, minimum=1)
+        _validate_integer("memory", memory, minimum=1)
+        _validate_integer("cpu_limit", cpu_limit, minimum=0)
+        _validate_integer("mem_limit", mem_limit, minimum=0)
+        _validate_integer("idle_timeout", idle_timeout, minimum=0)
+        if schedule_timeout != -1:
+            _validate_integer("schedule_timeout", schedule_timeout, minimum=1)
+        if cpu_limit and cpu_limit < cpu:
+            raise ValueError("cpu_limit must be 0 or greater than or equal to cpu")
+        if mem_limit and mem_limit < memory:
+            raise ValueError("mem_limit must be 0 or greater than or equal to memory")
         if env is not None:
             if not isinstance(env, Mapping) or not all(
                 isinstance(key, str) and isinstance(value, str)
@@ -162,10 +189,18 @@ class Sandbox:
                 raise TypeError("env must map strings to strings")
         if name is not None and (not isinstance(name, str) or not name.strip()):
             raise ValueError("name must be a non-empty string")
-        if cwd is not None and not isinstance(cwd, str):
-            raise TypeError("cwd must be a string")
+        if cwd is not None:
+            if not isinstance(cwd, str):
+                raise TypeError("cwd must be a string")
+            if not cwd.startswith("/"):
+                raise ValueError("cwd must be an absolute POSIX path")
         if not isinstance(detached, bool):
             raise TypeError("detached must be a boolean")
+        if node_id is not None:
+            if not isinstance(node_id, str):
+                raise TypeError("node_id must be a string")
+            if not node_id.strip():
+                raise ValueError("node_id must be a non-empty string")
         if reverse_tunnel is not None and not isinstance(
             reverse_tunnel, HttpReverseTunnel
         ):
@@ -184,8 +219,7 @@ class Sandbox:
                     f"{rendered}"
                 )
 
-        self._instance: Any = None
-        self._tunnel_client: Any = None
+        self._session: BackendSession | None = None
         self._pty: Pty | None = None
         self._closed = False
         self._detached = detached
@@ -196,43 +230,48 @@ class Sandbox:
         self._memory = memory
         self._id = ""
 
-        _openyuanrong.ensure_initialized()
-        options = _openyuanrong.build_options(
+        spec = SandboxSpec(
             image=image,
             rootfs=rootfs,
-            runtime=runtime,
+            runtime=cast(Literal["runsc", "kata"], runtime),
             cpu=cpu,
             memory=memory,
             cpu_limit=cpu_limit,
             mem_limit=mem_limit,
             idle_timeout=idle_timeout,
             schedule_timeout=schedule_timeout,
-            env=env,
+            env=MappingProxyType(dict(env or {})),
             name=name,
-            port_forwardings=ports,
-            mounts=mount_list,
+            command_cwd=cwd,
+            port_forwardings=tuple(ports),
+            mounts=tuple(mount_list),
             reverse_tunnel=reverse_tunnel,
             detached=detached,
             node_id=node_id,
         )
-        self._instance = _openyuanrong.create_instance(options, cwd=cwd)
-        self._id = _openyuanrong.real_instance_id(self._instance)
-
+        self._session = load_backend().create(spec)
         try:
-            if reverse_tunnel is not None:
-                self._tunnel_client = _openyuanrong.start_reverse_tunnel(
-                    self._instance,
-                    reverse_tunnel,
-                    name=name,
-                )
+            self._id = self._session.id
+            self._files = Filesystem(self._session.files)
+            self._commands = Commands(self._session.commands)
+            self._pty = Pty(self._id)
         except Exception:
-            _openyuanrong.terminate_instance(self._instance)
             self._closed = True
+            try:
+                self._session.terminate()
+            except Exception:
+                logger.warning(
+                    "failed to roll back a partially initialized sandbox",
+                    exc_info=True,
+                )
+            try:
+                self._session.close()
+            except Exception:
+                logger.warning(
+                    "failed to close a partially initialized sandbox session",
+                    exc_info=True,
+                )
             raise
-
-        self._files = Filesystem(self._instance, instance_id=self._id)
-        self._commands = Commands(self._instance)
-        self._pty = Pty(self._id)
 
     @property
     def files(self) -> Filesystem:
@@ -299,20 +338,22 @@ class Sandbox:
     def is_running(self) -> bool:
         """Return whether the sandbox currently responds to a health check."""
 
-        if self._closed or self._instance is None:
+        if self._closed or self._session is None:
             return False
-        return _openyuanrong.ping_instance(self._instance)
+        return self._session.is_running()
 
     def get_info(self) -> SandboxInfo:
         """Return current sandbox state and requested resources."""
 
-        return SandboxInfo(
-            id=self.id,
-            state=_openyuanrong.instance_state(self._instance),
-            cpu=self._cpu,
-            memory=self._memory,
-            image=self._image,
-        )
+        if self._session is None:
+            return SandboxInfo(
+                id=self.id,
+                state="stopped",
+                cpu=self._cpu,
+                memory=self._memory,
+                image=self._image,
+            )
+        return self._session.get_info()
 
     def kill(self) -> None:
         """Release client resources and terminate a non-detached sandbox."""
@@ -321,13 +362,40 @@ class Sandbox:
             return
         self._closed = True
 
-        if self._tunnel_client is not None:
-            self._tunnel_client.stop()
-            self._tunnel_client = None
+        local_errors: list[Exception] = []
+        terminate_error: Exception | None = None
+
         if self._pty is not None:
-            self._pty._close()
-        if not self._detached and self._instance is not None:
-            _openyuanrong.terminate_instance(self._instance)
+            try:
+                self._pty._close()
+            except Exception as error:
+                local_errors.append(error)
+
+        if self._session is not None:
+            if not self._detached:
+                try:
+                    self._session.terminate()
+                except Exception as error:
+                    terminate_error = error
+            try:
+                self._session.close()
+            except Exception as error:
+                local_errors.append(error)
+
+        if terminate_error is not None:
+            for cleanup_error in local_errors:
+                logger.warning(
+                    "local sandbox cleanup also failed after termination error: %s",
+                    cleanup_error,
+                )
+            raise terminate_error
+        if local_errors:
+            for cleanup_error in local_errors[1:]:
+                logger.warning(
+                    "additional sandbox cleanup failure: %s",
+                    cleanup_error,
+                )
+            raise local_errors[0]
 
     @classmethod
     def delete(cls, name: str) -> None:
@@ -339,7 +407,7 @@ class Sandbox:
 
         if not isinstance(name, str) or not name.strip():
             raise ValueError("name must be a non-empty string")
-        _openyuanrong.delete_named_instance(name)
+        load_backend().delete_named(name)
 
     def __enter__(self) -> Sandbox:
         return self

--- a/sdk/python/benchmarks/sandbox_pressure.py
+++ b/sdk/python/benchmarks/sandbox_pressure.py
@@ -44,7 +44,10 @@ Usage:
 """
 
 import argparse
+import faulthandler
+import multiprocessing
 import os
+import signal
 import socket
 import subprocess
 import sys
@@ -80,8 +83,9 @@ TUNNEL_CMD_TEMPLATE = (
 def _safe_kill(sb):
     try:
         sb.kill()
-    except Exception:
-        pass
+    except Exception as error:
+        return repr(error)[:300]
+    return None
 
 
 def _build_sandbox_kwargs(
@@ -115,12 +119,32 @@ def _build_sandbox_kwargs(
     return kwargs
 
 
+def _kill_with_timing(sb):
+    started = time.monotonic()
+    error = _safe_kill(sb)
+    return time.monotonic() - started, error
+
+
+def _record_cleanup(stats, cleanup_future):
+    try:
+        elapsed, error = cleanup_future.result()
+    except Exception as exc:
+        elapsed = 0.0
+        error = repr(exc)[:300]
+    with stats["lock"]:
+        stats["cleanup_latencies"].append(elapsed)
+        if error is not None:
+            stats["cleanup_failed"] += 1
+            stats["errors"].append(f"cleanup: {error}")
+
+
 def run_single_request(stats, term_pool, sb_kwargs, cmd, cmd_timeout, tunnel_mode):
-    t0 = time.time()
+    t0 = time.monotonic()
     sb = None
+    cleanup_future = None
     try:
         sb = Sandbox(**sb_kwargs)
-        t_created = time.time()
+        t_created = time.monotonic()
 
         if tunnel_mode:
             tunnel_url = sb.reverse_tunnel.url
@@ -135,28 +159,50 @@ def run_single_request(stats, term_pool, sb_kwargs, cmd, cmd_timeout, tunnel_mod
                 f"stdout={result.stdout!r} stderr={result.stderr!r}"
             )
 
-        elapsed = time.time() - t0
+        elapsed = time.monotonic() - t0
         with stats["lock"]:
             stats["success"] += 1
             stats["latencies"].append(elapsed)
             stats["create_latencies"].append(t_created - t0)
-
-        term_pool.submit(_safe_kill, sb)
-        sb = None
     except Exception as e:
         with stats["lock"]:
             stats["failed"] += 1
             stats["errors"].append(repr(e)[:300])
-        if sb is not None:
-            term_pool.submit(_safe_kill, sb)
     finally:
+        if sb is not None:
+            cleanup_future = term_pool.submit(_kill_with_timing, sb)
         with stats["lock"]:
             stats["total"] += 1
+    return cleanup_future
 
 
-def thread_loop(stats, term_pool, end_time, sb_kwargs, cmd, cmd_timeout, tunnel_mode):
-    while time.time() < end_time:
-        run_single_request(stats, term_pool, sb_kwargs, cmd, cmd_timeout, tunnel_mode)
+def thread_loop(
+    stats,
+    term_pool,
+    end_time,
+    sb_kwargs,
+    cmd,
+    cmd_timeout,
+    tunnel_mode,
+):
+    pending_cleanup = None
+    while time.monotonic() < end_time:
+        next_cleanup = run_single_request(
+            stats,
+            term_pool,
+            sb_kwargs,
+            cmd,
+            cmd_timeout,
+            tunnel_mode,
+        )
+        # Bound cleanup backlog to one item per load-generating thread. The
+        # current create/run overlaps with the previous sandbox's deletion,
+        # but cleanup cannot accumulate without limit.
+        if pending_cleanup is not None:
+            _record_cleanup(stats, pending_cleanup)
+        pending_cleanup = next_cleanup
+    if pending_cleanup is not None:
+        _record_cleanup(stats, pending_cleanup)
 
 
 def worker_process(
@@ -176,12 +222,16 @@ def worker_process(
     cmd_timeout,
     tunnel_mode,
 ):
+    if hasattr(signal, "SIGUSR1"):
+        faulthandler.register(signal.SIGUSR1, all_threads=True)
     stats = {
         "total": 0,
         "success": 0,
         "failed": 0,
+        "cleanup_failed": 0,
         "latencies": [],
         "create_latencies": [],
+        "cleanup_latencies": [],
         "errors": [],
         "lock": threading.Lock(),
     }
@@ -197,10 +247,12 @@ def worker_process(
         reverse_port,
         listen_port,
     )
-    term_pool = ThreadPoolExecutor(max_workers=max(4, threads_per_proc))
-    end_time = time.time() + duration
+    end_time = time.monotonic() + duration
 
-    with ThreadPoolExecutor(max_workers=threads_per_proc) as worker_pool:
+    with (
+        ThreadPoolExecutor(max_workers=threads_per_proc) as term_pool,
+        ThreadPoolExecutor(max_workers=threads_per_proc) as worker_pool,
+    ):
         futs = [
             worker_pool.submit(
                 thread_loop,
@@ -216,7 +268,6 @@ def worker_process(
         ]
         wait(futs)
 
-    term_pool.shutdown(wait=True)
     stats.pop("lock", None)
     return stats
 
@@ -278,7 +329,12 @@ def main(args):
     )
 
     try:
-        pool = ProcessPoolExecutor(max_workers=args.processes)
+        # Use spawn so SDK/native transport state is never inherited across a
+        # fork. Each child creates and owns all of its backend clients.
+        pool = ProcessPoolExecutor(
+            max_workers=args.processes,
+            mp_context=multiprocessing.get_context("spawn"),
+        )
         futs = [
             pool.submit(
                 worker_process,
@@ -301,25 +357,46 @@ def main(args):
             for _ in range(args.processes)
         ]
 
-        t_start = time.time()
-        done = wait(futs)
-        t_end = time.time()
+        t_start = time.monotonic()
+        pending = set(futs)
+        done_futs = set()
+        while pending:
+            completed, pending = wait(pending, timeout=args.progress_interval)
+            done_futs.update(completed)
+            if pending:
+                elapsed = time.monotonic() - t_start
+                phase = (
+                    "running load"
+                    if elapsed < args.duration
+                    else "finishing in-flight lifecycle"
+                )
+                print(
+                    f"[progress] elapsed={elapsed:.1f}s "
+                    f"workers={len(done_futs)}/{len(futs)} complete; "
+                    f"{len(pending)} worker(s) {phase}",
+                    flush=True,
+                )
+        t_end = time.monotonic()
 
         merged = {
             "total": 0,
             "success": 0,
             "failed": 0,
+            "cleanup_failed": 0,
             "latencies": [],
             "create_latencies": [],
+            "cleanup_latencies": [],
             "errors": [],
         }
-        for fut in done.done:
+        for fut in done_futs:
             s = fut.result()
             merged["total"] += s["total"]
             merged["success"] += s["success"]
             merged["failed"] += s["failed"]
+            merged["cleanup_failed"] += s["cleanup_failed"]
             merged["latencies"].extend(s["latencies"])
             merged["create_latencies"].extend(s["create_latencies"])
+            merged["cleanup_latencies"].extend(s["cleanup_latencies"])
             merged["errors"].extend(s["errors"])
 
         total_time = t_end - t_start
@@ -332,6 +409,7 @@ def main(args):
         print(f"🔁 Total Requests : {merged['total']}")
         print(f"✅ Success        : {merged['success']}")
         print(f"❌ Failed         : {merged['failed']}")
+        print(f"🧹 Cleanup Failed : {merged['cleanup_failed']}")
         print(f"⚡ RPS            : {rps:.2f}")
 
         def _percentiles(label, samples_s):
@@ -349,6 +427,7 @@ def main(args):
 
         _percentiles("create+run latency", merged["latencies"])
         _percentiles("create-only latency", merged["create_latencies"])
+        _percentiles("cleanup latency", merged["cleanup_latencies"])
 
         if merged["errors"]:
             print("\n— sample failures (up to 5) —")
@@ -432,6 +511,12 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument("--cmd-timeout", type=int, default=20)
+    parser.add_argument(
+        "--progress-interval",
+        type=float,
+        default=10,
+        help="seconds between progress messages while workers finish",
+    )
     args = parser.parse_args()
 
     main(args)

--- a/sdk/python/examples/gpu_sandbox.py
+++ b/sdk/python/examples/gpu_sandbox.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026 Ant Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Request a whole GPU device.
+
+The cluster must advertise a matching GPU resource. Set AKERNEL_GPU_MODEL to a
+scheduler-visible normalized model such as ``a10``, or leave it unset to accept
+any GPU model.
+"""
+
+import os
+
+from akernel_sdk import Sandbox
+
+
+def main() -> None:
+    model = os.environ.get("AKERNEL_GPU_MODEL", "").strip()
+    with Sandbox(xpu=f"gpu:{model}:1", cpu=1000, memory=2048) as sandbox:
+        result = sandbox.commands.run("nvidia-smi -L")
+        assert result.exit_code == 0, result.stderr
+        print(result.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Distributed Computing",
 ]

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -28,14 +28,22 @@ classifiers = [
     "Topic :: System :: Distributed Computing",
 ]
 dependencies = [
-    "openyuanrong-sdk==0.9.2",
+    "openyuanrong-sandbox==0.9.3",
     "websockets>=10.0",
 ]
 
 [project.optional-dependencies]
+openyuanrong-sdk = [
+    "openyuanrong-sdk==0.9.3",
+]
+openyuanrong-sandbox = []
+all = [
+    "openyuanrong-sdk==0.9.3",
+]
 dev = [
     "build>=1.2,<2",
     "mypy>=1.10,<2",
+    "openyuanrong-sdk==0.9.3",
     "ruff>=0.11,<1",
 ]
 

--- a/sdk/python/tests/unit/test_addresses.py
+++ b/sdk/python/tests/unit/test_addresses.py
@@ -79,6 +79,24 @@ class AddressConfigTest(unittest.TestCase):
                 ("https", "gw.example.com", 9443, True),
             )
 
+    def test_internal_yr_gateway_does_not_override_exec_endpoint(self):
+        with patch.dict(
+            os.environ,
+            {
+                "AKERNEL_SERVER_ADDRESS": "10.0.0.1",
+                "YR_GATEWAY_ADDRESS": "10.0.0.1:80",
+            },
+            clear=True,
+        ):
+            self.assertEqual(
+                endpoint_tuple(exec_endpoint_from_env()),
+                ("https", "10.0.0.1", 443, True),
+            )
+            self.assertEqual(
+                endpoint_tuple(gateway_endpoint_from_env()),
+                ("http", "10.0.0.1", 80, False),
+            )
+
     def test_missing_server_address_is_clear(self):
         with patch.dict(os.environ, {}, clear=True):
             with self.assertRaisesRegex(RuntimeError, "AKERNEL_SERVER_ADDRESS"):

--- a/sdk/python/tests/unit/test_backends.py
+++ b/sdk/python/tests/unit/test_backends.py
@@ -59,6 +59,7 @@ def _spec(**overrides):
         "reverse_tunnel": None,
         "detached": False,
         "node_id": None,
+        "xpu": None,
     }
     values.update(overrides)
     return SandboxSpec(**values)
@@ -155,6 +156,7 @@ class OpenYuanRongSandboxBackendTest(unittest.TestCase):
         with patch.object(
             openyuanrong_sandbox.yr_sandbox,
             "Sandbox",
+            autospec=True,
             return_value=native,
         ) as sandbox_type:
             session = self.backend.create(
@@ -170,6 +172,7 @@ class OpenYuanRongSandboxBackendTest(unittest.TestCase):
                     reverse_tunnel=tunnel,
                     detached=True,
                     node_id="node-1",
+                    xpu="gpu:NVIDIA-A10:2",
                 )
             )
 
@@ -184,6 +187,7 @@ class OpenYuanRongSandboxBackendTest(unittest.TestCase):
         self.assertEqual(kwargs["upstream"], "https://service.example")
         self.assertEqual(kwargs["create_timeout"], 60)
         self.assertEqual(kwargs["node_id"], "node-1")
+        self.assertEqual(kwargs["xpu"], "gpu:NVIDIA-A10:2")
 
         self.assertEqual(
             session.commands.run("echo ok", envs=None, cwd=None, timeout=60),

--- a/sdk/python/tests/unit/test_backends.py
+++ b/sdk/python/tests/unit/test_backends.py
@@ -1,0 +1,411 @@
+# Copyright (c) 2026 Ant Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+from types import MappingProxyType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from akernel_sdk._addresses import Endpoint
+from akernel_sdk._backends import (
+    openyuanrong_sandbox,
+    openyuanrong_sdk,
+    registry,
+)
+from akernel_sdk._backends.base import BackendConfig, SandboxSpec
+from akernel_sdk._backends.errors import (
+    BackendNotInstalledError,
+    BackendOperationError,
+    InvalidBackendError,
+    UnsupportedBackendFeatureError,
+)
+from akernel_sdk.types import (
+    CommandInfo,
+    CommandResult,
+    EntryInfo,
+    HttpReverseTunnel,
+    Mount,
+    S3Config,
+)
+
+
+def _spec(**overrides):
+    values = {
+        "image": None,
+        "rootfs": None,
+        "runtime": "runsc",
+        "cpu": 1000,
+        "memory": 4096,
+        "cpu_limit": 0,
+        "mem_limit": 0,
+        "idle_timeout": 300,
+        "schedule_timeout": 30,
+        "env": MappingProxyType({}),
+        "name": None,
+        "command_cwd": None,
+        "port_forwardings": (),
+        "mounts": (),
+        "reverse_tunnel": None,
+        "detached": False,
+        "node_id": None,
+    }
+    values.update(overrides)
+    return SandboxSpec(**values)
+
+
+class RegistryTest(unittest.TestCase):
+    def test_explicit_selection_wins_without_importing_backend(self):
+        with (
+            patch.dict(
+                os.environ,
+                {"AKERNEL_BACKEND": "openyuanrong-sdk"},
+                clear=True,
+            ),
+            patch.object(registry, "_is_installed") as installed,
+        ):
+            self.assertEqual(registry._select_backend(), "openyuanrong-sdk")
+        installed.assert_not_called()
+
+    def test_sandbox_has_auto_detection_priority(self):
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.object(registry, "_is_installed", return_value=True) as installed,
+        ):
+            self.assertEqual(registry._select_backend(), "openyuanrong-sandbox")
+        installed.assert_called_once_with("openyuanrong-sandbox")
+
+    def test_invalid_explicit_backend_fails_during_selection(self):
+        with (
+            patch.dict(os.environ, {"AKERNEL_BACKEND": "sandbox"}, clear=True),
+            self.assertRaisesRegex(InvalidBackendError, "openyuanrong-sandbox"),
+        ):
+            registry._select_backend()
+
+    def test_missing_default_backend_recommends_plain_install(self):
+        error = registry._not_installed_error("openyuanrong-sandbox")
+        self.assertIsInstance(error, BackendNotInstalledError)
+        self.assertIn("pip install akernel-sdk", str(error))
+        self.assertNotIn("[openyuanrong-sandbox]", str(error))
+
+    def test_missing_actor_backend_recommends_named_extra(self):
+        error = registry._not_installed_error("openyuanrong-sdk")
+        self.assertIn("akernel-sdk[openyuanrong-sdk]", str(error))
+
+
+class OpenYuanRongSandboxBackendTest(unittest.TestCase):
+    def setUp(self):
+        self.config = BackendConfig(
+            api_endpoint=Endpoint("api.example", 443, "https", True),
+            gateway_endpoint=Endpoint("gateway.example", 80, "http", True),
+            token="secret",
+        )
+        self.environment = patch.dict(os.environ, {}, clear=True)
+        self.environment.start()
+        self.addCleanup(self.environment.stop)
+        self.backend = openyuanrong_sandbox.OpenYuanRongSandboxBackend(self.config)
+
+    def test_connection_config_maps_to_yr_environment(self):
+        self.assertEqual(os.environ["YR_SERVER_ADDRESS"], "api.example:443")
+        self.assertEqual(os.environ["YR_TLS"], "1")
+        self.assertEqual(os.environ["YR_GATEWAY_ADDRESS"], "gateway.example:80")
+        self.assertEqual(os.environ["YR_GATEWAY_TLS"], "0")
+        self.assertEqual(os.environ["YR_TOKEN"], "secret")
+
+    def test_create_converts_inputs_and_preserves_akernel_outputs(self):
+        native = MagicMock()
+        native.id = "default-worker"
+        native_info = SimpleNamespace(
+            id="default-worker",
+            state="running",
+            cpu=2000,
+            memory=8192,
+            image=None,
+        )
+        native.get_info.return_value = native_info
+        native.commands.run.return_value = SimpleNamespace(
+            stdout="ok\n",
+            stderr="",
+            exit_code=0,
+        )
+        native.commands.list.return_value = [
+            SimpleNamespace(pid=7, command="sleep 1", running=True)
+        ]
+        native.files.get_info.return_value = SimpleNamespace(
+            name="a.txt",
+            path="/tmp/a.txt",
+            type="file",
+            size=3,
+            permissions="rw-r--r--",
+            modified_time=1.0,
+        )
+        rootfs = S3Config("https://s3.example", "rootfs", "rootfs.img")
+        mount = Mount(target="/tools", image_url="tools:v1")
+        tunnel = HttpReverseTunnel("https://service.example")
+        with patch.object(
+            openyuanrong_sandbox.yr_sandbox,
+            "Sandbox",
+            return_value=native,
+        ) as sandbox_type:
+            session = self.backend.create(
+                _spec(
+                    rootfs=rootfs,
+                    runtime="kata",
+                    cpu=2000,
+                    memory=8192,
+                    name="worker",
+                    command_cwd="/workspace",
+                    port_forwardings=(8080,),
+                    mounts=(mount,),
+                    reverse_tunnel=tunnel,
+                    detached=True,
+                    node_id="node-1",
+                )
+            )
+
+        kwargs = sandbox_type.call_args.kwargs
+        self.assertIsInstance(
+            kwargs["rootfs"],
+            openyuanrong_sandbox.yr_sandbox.S3Config,
+        )
+        self.assertEqual(kwargs["runtime"], "kata")
+        self.assertEqual(kwargs["cwd"], "/workspace")
+        self.assertEqual(kwargs["port_forwardings"], [8080])
+        self.assertEqual(kwargs["upstream"], "https://service.example")
+        self.assertEqual(kwargs["create_timeout"], 60)
+        self.assertEqual(kwargs["node_id"], "node-1")
+
+        self.assertEqual(
+            session.commands.run("echo ok", envs=None, cwd=None, timeout=60),
+            CommandResult("ok\n", "", 0),
+        )
+        self.assertEqual(
+            session.commands.list(),
+            [CommandInfo(pid=7, command="sleep 1", running=True)],
+        )
+        self.assertEqual(
+            session.files.get_info("/tmp/a.txt"),
+            EntryInfo(
+                name="a.txt",
+                path="/tmp/a.txt",
+                type="file",
+                size=3,
+                permissions="rw-r--r--",
+                modified_time=1.0,
+            ),
+        )
+        self.assertEqual(session.get_info().id, "default-worker")
+        session.close()
+        native.kill.assert_called_once_with()
+
+    def test_unbounded_schedule_timeout_is_rejected_before_create(self):
+        with (
+            patch.object(openyuanrong_sandbox.yr_sandbox, "Sandbox") as sandbox_type,
+            self.assertRaisesRegex(
+                UnsupportedBackendFeatureError,
+                "schedule_timeout=-1",
+            ),
+        ):
+            self.backend.create(_spec(schedule_timeout=-1))
+        sandbox_type.assert_not_called()
+
+    def test_terminate_forces_deletion_of_detached_native_sandbox(self):
+        native = MagicMock()
+        native.id = "default-worker"
+        native.commands = MagicMock()
+        native.files = MagicMock()
+        with patch.object(
+            openyuanrong_sandbox.yr_sandbox,
+            "Sandbox",
+            return_value=native,
+        ) as sandbox_type:
+            session = self.backend.create(_spec(detached=True))
+            session.terminate()
+            session.close()
+
+        sandbox_type.delete.assert_called_once_with("default-worker")
+        native.kill.assert_called_once_with()
+
+    def test_detached_delete_failure_still_allows_local_cleanup(self):
+        native = MagicMock()
+        native.id = "default-worker"
+        native.commands = MagicMock()
+        native.files = MagicMock()
+        with (
+            patch.object(
+                openyuanrong_sandbox.yr_sandbox,
+                "Sandbox",
+                return_value=native,
+            ) as sandbox_type,
+            self.assertRaisesRegex(BackendOperationError, "remote delete failed"),
+        ):
+            sandbox_type.delete.side_effect = RuntimeError("remote delete failed")
+            session = self.backend.create(_spec(detached=True))
+            try:
+                session.terminate()
+            finally:
+                session.close()
+
+        sandbox_type.delete.assert_called_once_with("default-worker")
+        native.kill.assert_called_once_with()
+
+    def test_custom_reverse_tunnel_ports_are_rejected(self):
+        tunnel = HttpReverseTunnel(
+            "https://service.example",
+            reverse_port=9000,
+            listen_port=9001,
+        )
+        with self.assertRaisesRegex(
+            UnsupportedBackendFeatureError,
+            "8765 and 8766",
+        ):
+            self.backend.create(_spec(reverse_tunnel=tunnel))
+
+    def test_named_delete_uses_deterministic_sid(self):
+        with patch.object(
+            openyuanrong_sandbox.yr_sandbox.Sandbox,
+            "delete",
+        ) as delete:
+            self.backend.delete_named("worker")
+        delete.assert_called_once_with("default-worker")
+
+
+class OpenYuanRongSdkBackendTest(unittest.TestCase):
+    def setUp(self):
+        self.config = BackendConfig(
+            api_endpoint=Endpoint("api.example", 443, "https", True),
+            gateway_endpoint=Endpoint("gateway.example", 80, "http", True),
+            token="secret",
+        )
+        initialized = patch.object(openyuanrong_sdk._openyuanrong, "ensure_initialized")
+        initialized.start()
+        self.addCleanup(initialized.stop)
+        self.backend = openyuanrong_sdk.OpenYuanRongSdkBackend(self.config)
+
+    def test_physical_id_failure_rolls_back_created_actor(self):
+        instance = MagicMock()
+        physical_id_error = RuntimeError("physical ID unavailable")
+        with (
+            patch.object(
+                openyuanrong_sdk._openyuanrong,
+                "build_options",
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                openyuanrong_sdk._openyuanrong,
+                "create_instance",
+                return_value=instance,
+            ),
+            patch.object(
+                openyuanrong_sdk._openyuanrong,
+                "real_instance_id",
+                side_effect=physical_id_error,
+            ),
+            patch.object(
+                openyuanrong_sdk._openyuanrong,
+                "terminate_instance",
+            ) as terminate,
+            self.assertRaisesRegex(
+                BackendOperationError,
+                "physical ID unavailable",
+            ) as raised,
+        ):
+            self.backend.create(_spec())
+
+        self.assertIs(raised.exception.__cause__, physical_id_error)
+        terminate.assert_called_once_with(instance)
+
+    def test_rollback_failure_does_not_replace_physical_id_error(self):
+        instance = MagicMock()
+        physical_id_error = RuntimeError("physical ID unavailable")
+        with (
+            patch.object(
+                openyuanrong_sdk._openyuanrong,
+                "build_options",
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                openyuanrong_sdk._openyuanrong,
+                "create_instance",
+                return_value=instance,
+            ),
+            patch.object(
+                openyuanrong_sdk._openyuanrong,
+                "real_instance_id",
+                side_effect=physical_id_error,
+            ),
+            patch.object(
+                openyuanrong_sdk._openyuanrong,
+                "terminate_instance",
+                side_effect=RuntimeError("rollback failed"),
+            ) as terminate,
+            self.assertLogs(openyuanrong_sdk.logger, level="WARNING"),
+            self.assertRaisesRegex(
+                BackendOperationError,
+                "physical ID unavailable",
+            ) as raised,
+        ):
+            self.backend.create(_spec())
+
+        self.assertIs(raised.exception.__cause__, physical_id_error)
+        terminate.assert_called_once_with(instance)
+
+    def test_termination_failure_still_closes_reverse_tunnel(self):
+        instance = MagicMock()
+        tunnel_client = MagicMock()
+        terminate_error = RuntimeError("remote delete failed")
+        with (
+            patch.object(
+                openyuanrong_sdk._openyuanrong,
+                "build_options",
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                openyuanrong_sdk._openyuanrong,
+                "create_instance",
+                return_value=instance,
+            ),
+            patch.object(
+                openyuanrong_sdk._openyuanrong,
+                "real_instance_id",
+                return_value="physical-id",
+            ),
+            patch.object(
+                openyuanrong_sdk._openyuanrong,
+                "start_reverse_tunnel",
+                return_value=tunnel_client,
+            ),
+            patch.object(
+                openyuanrong_sdk._openyuanrong,
+                "terminate_instance",
+                side_effect=terminate_error,
+            ),
+        ):
+            session = self.backend.create(
+                _spec(reverse_tunnel=HttpReverseTunnel("http://127.0.0.1:9000"))
+            )
+            try:
+                with self.assertRaisesRegex(
+                    BackendOperationError,
+                    "remote delete failed",
+                ) as raised:
+                    session.terminate()
+            finally:
+                session.close()
+
+        self.assertIs(raised.exception.__cause__, terminate_error)
+        tunnel_client.stop.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/python/tests/unit/test_commands.py
+++ b/sdk/python/tests/unit/test_commands.py
@@ -15,7 +15,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from akernel_sdk.commands import CommandHandle, Commands
+from akernel_sdk._backends.openyuanrong_sdk_commands import CommandHandle, Commands
 from akernel_sdk.types import CommandInfo, CommandResult
 
 
@@ -27,7 +27,7 @@ class CommandsTest(unittest.TestCase):
         token = object()
         self.instance.cmd_list.invoke.return_value = token
         with patch(
-            "akernel_sdk.commands.yr.get",
+            "akernel_sdk._backends.openyuanrong_sdk_commands.yr.get",
             return_value={
                 "processes": [
                     {"pid": 42, "cmd": "sleep 30", "running": True},
@@ -44,7 +44,7 @@ class CommandsTest(unittest.TestCase):
         token = object()
         self.instance.cmd_run.invoke.return_value = token
         with patch(
-            "akernel_sdk.commands.yr.get",
+            "akernel_sdk._backends.openyuanrong_sdk_commands.yr.get",
             return_value={"stdout": "ok\n", "stderr": "", "exit_code": 0},
         ) as get:
             result = Commands(self.instance).run("echo ok", timeout=60)
@@ -66,7 +66,7 @@ class CommandsTest(unittest.TestCase):
         token = object()
         self.instance.cmd_start.invoke.return_value = token
         with patch(
-            "akernel_sdk.commands.yr.get",
+            "akernel_sdk._backends.openyuanrong_sdk_commands.yr.get",
             return_value={"pid": 99, "error": None},
         ):
             result = Commands(self.instance).run(
@@ -82,7 +82,7 @@ class CommandsTest(unittest.TestCase):
     def test_background_start_error_is_reported(self):
         self.instance.cmd_start.invoke.return_value = object()
         with patch(
-            "akernel_sdk.commands.yr.get",
+            "akernel_sdk._backends.openyuanrong_sdk_commands.yr.get",
             return_value={"pid": -1, "error": "exec failed"},
         ):
             with self.assertRaisesRegex(RuntimeError, "exec failed"):
@@ -92,7 +92,7 @@ class CommandsTest(unittest.TestCase):
         token = object()
         self.instance.cmd_wait.invoke.return_value = token
         with patch(
-            "akernel_sdk.commands.yr.get",
+            "akernel_sdk._backends.openyuanrong_sdk_commands.yr.get",
             return_value={"stdout": "done", "stderr": "", "exit_code": 0},
         ) as get:
             result = CommandHandle(7, self.instance).wait(timeout=60)
@@ -105,7 +105,7 @@ class CommandsTest(unittest.TestCase):
         token = object()
         self.instance.cmd_wait.invoke.return_value = token
         with patch(
-            "akernel_sdk.commands.yr.get",
+            "akernel_sdk._backends.openyuanrong_sdk_commands.yr.get",
             return_value={"stdout": "done", "stderr": "", "exit_code": 0},
         ) as get:
             CommandHandle(7, self.instance).wait()

--- a/sdk/python/tests/unit/test_facades.py
+++ b/sdk/python/tests/unit/test_facades.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 Ant Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock
+
+from akernel_sdk.commands import CommandHandle, Commands
+from akernel_sdk.filesystem import Filesystem
+from akernel_sdk.types import CommandResult
+
+
+class CommandFacadeTest(unittest.TestCase):
+    def test_foreground_and_background_operations_delegate_to_driver(self):
+        driver = MagicMock()
+        driver.run.return_value = CommandResult("ok", "", 0)
+        driver.start.return_value = 17
+        commands = Commands(driver)
+
+        self.assertEqual(commands.run("echo ok"), CommandResult("ok", "", 0))
+        driver.run.assert_called_once_with(
+            "echo ok",
+            envs=None,
+            cwd=None,
+            timeout=60,
+        )
+
+        handle = commands.run("cat", background=True, stdin=True)
+        self.assertIsInstance(handle, CommandHandle)
+        self.assertEqual(handle.pid, 17)
+        handle.send_stdin("hello", eof=True)
+        driver.send_stdin.assert_called_once_with(17, "hello", True)
+
+
+class FilesystemFacadeTest(unittest.TestCase):
+    def test_read_format_is_validated_and_translated(self):
+        driver = MagicMock()
+        driver.read.side_effect = ["hello", b"\x00\x01"]
+        files = Filesystem(driver)
+
+        self.assertEqual(files.read("/tmp/a"), "hello")
+        self.assertEqual(files.read("/tmp/b", format="bytes"), b"\x00\x01")
+        self.assertEqual(
+            driver.read.call_args_list[0].kwargs,
+            {"binary": False},
+        )
+        self.assertEqual(
+            driver.read.call_args_list[1].kwargs,
+            {"binary": True},
+        )
+        with self.assertRaisesRegex(ValueError, "format"):
+            files.read("/tmp/c", format="json")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/python/tests/unit/test_filesystem.py
+++ b/sdk/python/tests/unit/test_filesystem.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from yr.cli.exec import CopyRequest, ExecConnection
 
-from akernel_sdk.filesystem import Filesystem
+from akernel_sdk._backends.openyuanrong_sdk_filesystem import Filesystem
 from akernel_sdk.types import EntryInfo
 
 
@@ -31,7 +31,7 @@ class FilesystemTest(unittest.TestCase):
 
     def test_read_text_and_bytes(self):
         with patch(
-            "akernel_sdk.filesystem.yr.get",
+            "akernel_sdk._backends.openyuanrong_sdk_filesystem.yr.get",
             side_effect=[
                 {"data": "hello", "error": None},
                 {"data": "0001ff", "error": None},
@@ -46,7 +46,7 @@ class FilesystemTest(unittest.TestCase):
 
     def test_list_returns_entry_info(self):
         with patch(
-            "akernel_sdk.filesystem.yr.get",
+            "akernel_sdk._backends.openyuanrong_sdk_filesystem.yr.get",
             return_value={
                 "entries": [
                     {

--- a/sdk/python/tests/unit/test_openyuanrong.py
+++ b/sdk/python/tests/unit/test_openyuanrong.py
@@ -14,7 +14,7 @@
 
 import json
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from akernel_sdk import HttpReverseTunnel, Mount, S3Config, _openyuanrong
 
@@ -134,6 +134,52 @@ class OpenYuanRongAdapterTest(unittest.TestCase):
                 result = _openyuanrong.resources()
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].id, "node-1")
+
+    def test_readiness_failure_rolls_back_created_actor(self):
+        instance = MagicMock()
+        invoke = MagicMock(return_value=instance)
+        instance_type = MagicMock()
+        instance_type.options.return_value.invoke = invoke
+        readiness_error = RuntimeError("readiness failed")
+        with (
+            patch.object(_openyuanrong, "_SandboxInstance", instance_type),
+            patch.object(
+                _openyuanrong.yr,
+                "get",
+                side_effect=readiness_error,
+            ),
+            patch.object(_openyuanrong, "terminate_instance") as terminate,
+            self.assertRaisesRegex(RuntimeError, "readiness failed") as raised,
+        ):
+            _openyuanrong.create_instance(MagicMock(), cwd="/workspace")
+
+        self.assertIs(raised.exception, readiness_error)
+        terminate.assert_called_once_with(instance)
+
+    def test_readiness_rollback_failure_preserves_original_error(self):
+        instance = MagicMock()
+        instance_type = MagicMock()
+        instance_type.options.return_value.invoke.return_value = instance
+        readiness_error = RuntimeError("readiness failed")
+        with (
+            patch.object(_openyuanrong, "_SandboxInstance", instance_type),
+            patch.object(
+                _openyuanrong.yr,
+                "get",
+                side_effect=readiness_error,
+            ),
+            patch.object(
+                _openyuanrong,
+                "terminate_instance",
+                side_effect=RuntimeError("rollback failed"),
+            ) as terminate,
+            self.assertLogs(_openyuanrong.logger, level="WARNING"),
+            self.assertRaisesRegex(RuntimeError, "readiness failed") as raised,
+        ):
+            _openyuanrong.create_instance(MagicMock(), cwd=None)
+
+        self.assertIs(raised.exception, readiness_error)
+        terminate.assert_called_once_with(instance)
 
 
 if __name__ == "__main__":

--- a/sdk/python/tests/unit/test_openyuanrong.py
+++ b/sdk/python/tests/unit/test_openyuanrong.py
@@ -38,6 +38,7 @@ class OpenYuanRongAdapterTest(unittest.TestCase):
             "reverse_tunnel": None,
             "detached": False,
             "node_id": None,
+            "xpu": None,
         }
         values.update(overrides)
         return _openyuanrong.build_options(**values)
@@ -100,6 +101,16 @@ class OpenYuanRongAdapterTest(unittest.TestCase):
             self.build_options(cpu=2000, cpu_limit=1000)
         with self.assertRaisesRegex(ValueError, "mem_limit"):
             self.build_options(memory=4096, mem_limit=2048)
+
+    def test_xpu_translation(self):
+        specific = self.build_options(xpu="gpu:NVIDIA-A10:2")
+        self.assertEqual(
+            specific.custom_resources,
+            {"GPU/NVIDIA-A10/count": 2.0},
+        )
+
+        any_model = self.build_options(xpu="GPU::1")
+        self.assertEqual(any_model.custom_resources, {"GPU/.+/count": 1.0})
 
     def test_node_info_conversion(self):
         node = _openyuanrong._to_node_info(

--- a/sdk/python/tests/unit/test_resources.py
+++ b/sdk/python/tests/unit/test_resources.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026 Ant Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from akernel_sdk import _resources
+from akernel_sdk._addresses import Endpoint
+
+
+class ResourcesTest(unittest.TestCase):
+    def test_frontend_resource_values_are_backend_neutral(self):
+        payload = {
+            "resource": {
+                "fragment": {
+                    "node-1": {
+                        "id": "node-1",
+                        "status": 0,
+                        "capacity": {
+                            "resources": {
+                                "CPU": {"scalar": {"value": 8000}},
+                            }
+                        },
+                        "allocatable": {
+                            "resources": {
+                                "CPU": {"scalar": {"value": 6000}},
+                            }
+                        },
+                        "nodeLabels": {
+                            "HOST_IP": {"items": {"192.0.2.10": 1}},
+                        },
+                    }
+                }
+            }
+        }
+        response = MagicMock()
+        response.read.return_value = json.dumps(payload).encode()
+        context = MagicMock()
+        context.__enter__.return_value = response
+        with (
+            patch.dict(os.environ, {"AKERNEL_TOKEN": "token"}, clear=True),
+            patch.object(
+                _resources,
+                "api_endpoint_from_env",
+                return_value=Endpoint("api.example", 443, "https", False),
+            ),
+            patch.object(_resources.request, "urlopen", return_value=context),
+        ):
+            result = _resources.resources()
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].id, "node-1")
+        self.assertEqual(result[0].capacity["CPU"], 8000.0)
+        self.assertEqual(result[0].allocatable["CPU"], 6000.0)
+        self.assertEqual(result[0].labels["HOST_IP"], ["192.0.2.10"])
+
+    def test_token_is_required_without_loading_a_backend(self):
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch.object(
+                _resources,
+                "api_endpoint_from_env",
+                return_value=Endpoint("api.example", 443, "https", False),
+            ),
+            self.assertRaisesRegex(RuntimeError, "AKERNEL_TOKEN"),
+        ):
+            _resources.resources()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/python/tests/unit/test_sandbox.py
+++ b/sdk/python/tests/unit/test_sandbox.py
@@ -56,6 +56,7 @@ class SandboxTest(unittest.TestCase):
         self.assertEqual(spec.cpu, 2000)
         self.assertEqual(spec.memory, 8192)
         self.assertEqual(dict(spec.env), {})
+        self.assertIsNone(spec.xpu)
 
         sandbox.kill()
         self.session.terminate.assert_called_once_with()
@@ -140,6 +141,29 @@ class SandboxTest(unittest.TestCase):
             Sandbox(cpu=2000, cpu_limit=1000)
         with self.assertRaisesRegex(ValueError, "schedule_timeout"):
             Sandbox(schedule_timeout=0)
+        self.backend.create.assert_not_called()
+
+    def test_xpu_request_is_passed_to_backend(self):
+        sandbox = Sandbox(xpu="gpu:NVIDIA-A10:2")
+        spec = self.backend.create.call_args.args[0]
+        self.assertEqual(spec.xpu, "gpu:NVIDIA-A10:2")
+        sandbox.kill()
+
+    def test_xpu_request_is_validated_before_backend(self):
+        invalid = (
+            (1, TypeError, "string"),
+            ("gpu", ValueError, "three fields"),
+            (" gpu::1", ValueError, "whitespace"),
+            ("npu::1", ValueError, "unsupported xpu type"),
+            ("gpu::0", ValueError, "positive integer"),
+            ("gpu::1.5", ValueError, "positive integer"),
+        )
+        for value, error_type, message in invalid:
+            with self.subTest(value=value), self.assertRaisesRegex(
+                error_type,
+                message,
+            ):
+                Sandbox(xpu=value)
         self.backend.create.assert_not_called()
 
     def test_port_forwardings_are_integer_ports(self):

--- a/sdk/python/tests/unit/test_sandbox.py
+++ b/sdk/python/tests/unit/test_sandbox.py
@@ -14,39 +14,36 @@
 
 import os
 import unittest
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from akernel_sdk import HttpReverseTunnel, S3Config, Sandbox
 from akernel_sdk import sandbox as sandbox_module
+from akernel_sdk.types import SandboxInfo
 
 
 class SandboxTest(unittest.TestCase):
     def setUp(self):
-        self.handle = SimpleNamespace(instance_id="logical-id")
-        self.client = MagicMock()
-        backend = sandbox_module._openyuanrong
-        self.patchers = [
-            patch.object(backend, "ensure_initialized"),
-            patch.object(backend, "build_options", return_value="options"),
-            patch.object(backend, "create_instance", return_value=self.handle),
-            patch.object(backend, "real_instance_id", return_value="physical-id"),
-            patch.object(backend, "terminate_instance"),
-            patch.object(backend, "delete_named_instance"),
-            patch.object(backend, "ping_instance", return_value=True),
-            patch.object(backend, "instance_state", return_value="running"),
-            patch.object(backend, "start_reverse_tunnel", return_value=self.client),
-        ]
-        self.mocks = [patcher.start() for patcher in self.patchers]
-        self.addCleanup(self._stop_patchers)
-
-    def _stop_patchers(self):
-        for patcher in reversed(self.patchers):
-            patcher.stop()
-
-    @property
-    def backend(self):
-        return sandbox_module._openyuanrong
+        self.session = MagicMock()
+        self.session.id = "physical-id"
+        self.session.commands = MagicMock()
+        self.session.files = MagicMock()
+        self.session.is_running.return_value = True
+        self.session.get_info.return_value = SandboxInfo(
+            id="physical-id",
+            state="running",
+            cpu=2000,
+            memory=8192,
+            image=None,
+        )
+        self.backend = MagicMock()
+        self.backend.create.return_value = self.session
+        self.load_backend = patch.object(
+            sandbox_module,
+            "load_backend",
+            return_value=self.backend,
+        )
+        self.load_backend.start()
+        self.addCleanup(self.load_backend.stop)
 
     def test_default_constructor_and_info(self):
         sandbox = Sandbox(cpu=2000, memory=8192)
@@ -54,25 +51,68 @@ class SandboxTest(unittest.TestCase):
         self.assertIsNone(sandbox.reverse_tunnel)
         self.assertTrue(sandbox.is_running())
         self.assertEqual(sandbox.get_info().id, "physical-id")
-        self.assertEqual(sandbox.get_info().cpu, 2000)
-        self.backend.build_options.assert_called_once()
+
+        spec = self.backend.create.call_args.args[0]
+        self.assertEqual(spec.cpu, 2000)
+        self.assertEqual(spec.memory, 8192)
+        self.assertEqual(dict(spec.env), {})
+
         sandbox.kill()
-        self.backend.terminate_instance.assert_called_once_with(self.handle)
+        self.session.terminate.assert_called_once_with()
+        self.session.close.assert_called_once_with()
 
     def test_kill_is_idempotent(self):
         sandbox = Sandbox()
         sandbox.kill()
         sandbox.kill()
-        self.backend.terminate_instance.assert_called_once_with(self.handle)
+        self.session.terminate.assert_called_once_with()
+        self.session.close.assert_called_once_with()
 
     def test_detached_sandbox_is_not_terminated_by_kill(self):
         sandbox = Sandbox(name="worker", detached=True)
         sandbox.kill()
-        self.backend.terminate_instance.assert_not_called()
+        self.session.terminate.assert_not_called()
+        self.session.close.assert_called_once_with()
+
+    def test_termination_failure_still_closes_local_resources(self):
+        remote_error = RuntimeError("remote delete failed")
+        self.session.terminate.side_effect = remote_error
+        sandbox = Sandbox()
+        pty = MagicMock()
+        sandbox._pty = pty
+
+        with self.assertRaisesRegex(RuntimeError, "remote delete failed") as raised:
+            sandbox.kill()
+
+        self.assertIs(raised.exception, remote_error)
+        pty._close.assert_called_once_with()
+        self.session.close.assert_called_once_with()
+
+    def test_termination_error_takes_precedence_over_local_cleanup_error(self):
+        remote_error = RuntimeError("remote delete failed")
+        self.session.terminate.side_effect = remote_error
+        self.session.close.side_effect = RuntimeError("client close failed")
+        sandbox = Sandbox()
+        pty = MagicMock()
+        pty._close.side_effect = RuntimeError("PTY close failed")
+        sandbox._pty = pty
+
+        with (
+            self.assertLogs(sandbox_module.logger, level="WARNING"),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "remote delete failed",
+            ) as raised,
+        ):
+            sandbox.kill()
+
+        self.assertIs(raised.exception, remote_error)
+        pty._close.assert_called_once_with()
+        self.session.close.assert_called_once_with()
 
     def test_named_delete_hides_backend_namespace(self):
         Sandbox.delete("worker")
-        self.backend.delete_named_instance.assert_called_once_with("worker")
+        self.backend.delete_named.assert_called_once_with("worker")
 
     def test_rootfs_requires_s3_config(self):
         with self.assertRaisesRegex(TypeError, "S3Config"):
@@ -82,12 +122,25 @@ class SandboxTest(unittest.TestCase):
                 image="ubuntu:24.04",
                 rootfs=S3Config("https://s3.example.com", "rootfs", "rootfs.img"),
             )
+        self.backend.create.assert_not_called()
 
     def test_supported_runtimes(self):
-        Sandbox(runtime="kata")
+        sandbox = Sandbox(runtime="kata")
+        sandbox.kill()
 
         with self.assertRaisesRegex(ValueError, "unsupported runtime"):
             Sandbox(runtime="unknown")
+
+    def test_cwd_must_be_absolute(self):
+        with self.assertRaisesRegex(ValueError, "absolute POSIX"):
+            Sandbox(cwd="workspace")
+
+    def test_common_resource_validation_happens_before_backend(self):
+        with self.assertRaisesRegex(ValueError, "cpu_limit"):
+            Sandbox(cpu=2000, cpu_limit=1000)
+        with self.assertRaisesRegex(ValueError, "schedule_timeout"):
+            Sandbox(schedule_timeout=0)
+        self.backend.create.assert_not_called()
 
     def test_port_forwardings_are_integer_ports(self):
         with self.assertRaisesRegex(TypeError, "integer"):
@@ -95,33 +148,66 @@ class SandboxTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "duplicate"):
             Sandbox(port_forwardings=[8080, 8080])
 
-    def test_reverse_tunnel_lifecycle(self):
+    def test_reverse_tunnel_is_passed_through_spec(self):
         tunnel = HttpReverseTunnel(
-            "https://example.com", reverse_port=9000, listen_port=9001
+            "https://example.com",
+            reverse_port=9000,
+            listen_port=9001,
         )
         sandbox = Sandbox(reverse_tunnel=tunnel)
         self.assertIs(sandbox.reverse_tunnel, tunnel)
         self.assertEqual(sandbox.reverse_tunnel.url, "http://127.0.0.1:9001")
-        self.backend.start_reverse_tunnel.assert_called_once_with(
-            self.handle, tunnel, name=None
-        )
+        spec = self.backend.create.call_args.args[0]
+        self.assertIs(spec.reverse_tunnel, tunnel)
         sandbox.kill()
-        self.client.stop.assert_called_once()
+        self.session.close.assert_called_once_with()
 
     def test_reverse_tunnel_port_conflict(self):
         tunnel = HttpReverseTunnel(
-            "http://127.0.0.1:8000", reverse_port=9000, listen_port=9001
+            "http://127.0.0.1:8000",
+            reverse_port=9000,
+            listen_port=9001,
         )
         with self.assertRaisesRegex(ValueError, "conflict"):
             Sandbox(port_forwardings=[9000], reverse_tunnel=tunnel)
         with self.assertRaisesRegex(ValueError, "conflict"):
             Sandbox(port_forwardings=[9001], reverse_tunnel=tunnel)
 
-    def test_tunnel_start_failure_terminates_instance(self):
-        self.backend.start_reverse_tunnel.side_effect = RuntimeError("timeout")
+    def test_backend_create_failure_is_reported(self):
+        self.backend.create.side_effect = RuntimeError("timeout")
         with self.assertRaisesRegex(RuntimeError, "timeout"):
             Sandbox(reverse_tunnel=HttpReverseTunnel("example.com"), detached=True)
-        self.backend.terminate_instance.assert_called_once_with(self.handle)
+
+    def test_partial_facade_initialization_rolls_back_remote_sandbox(self):
+        with (
+            patch.object(sandbox_module, "Pty", side_effect=RuntimeError("pty")),
+            self.assertRaisesRegex(RuntimeError, "pty"),
+        ):
+            Sandbox(detached=True)
+        self.session.terminate.assert_called_once_with()
+        self.session.close.assert_called_once_with()
+
+    def test_partial_facade_cleanup_preserves_initialization_error(self):
+        self.session.terminate.side_effect = RuntimeError("remote delete failed")
+        self.session.close.side_effect = RuntimeError("client close failed")
+        initialization_error = RuntimeError("PTY initialization failed")
+        with (
+            patch.object(
+                sandbox_module,
+                "Pty",
+                side_effect=initialization_error,
+            ),
+            self.assertLogs(sandbox_module.logger, level="WARNING"),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "PTY initialization failed",
+            ) as raised,
+        ):
+            Sandbox(name="worker", detached=True)
+
+        self.assertIs(raised.exception, initialization_error)
+        self.session.terminate.assert_called_once_with()
+        self.session.close.assert_called_once_with()
 
     def test_get_port_url(self):
         with patch.dict(

--- a/sdk/python/tests/unit/test_types.py
+++ b/sdk/python/tests/unit/test_types.py
@@ -34,6 +34,7 @@ os.environ.pop('YR_HTTP_CONNECTION_NUM', None)
 import akernel_sdk
 import akernel_sdk.cli
 assert 'yr' not in sys.modules
+assert 'yr_sandbox' not in sys.modules
 assert 'YR_HTTP_CONNECTION_NUM' not in os.environ
 """
         result = subprocess.run(
@@ -63,6 +64,11 @@ assert 'YR_HTTP_CONNECTION_NUM' not in os.environ
                 "PtySession",
                 "PtyError",
                 "resources",
+                "get_backend",
+                "InvalidBackendError",
+                "BackendNotInstalledError",
+                "UnsupportedBackendFeatureError",
+                "BackendOperationError",
             },
         )
         for removed in (


### PR DESCRIPTION
## Summary

- introduce a backend-neutral boundary for sandbox lifecycle, commands, and filesystem operations
- move the existing `openyuanrong-sdk` actor implementation behind an adapter
- add an `openyuanrong-sandbox` HTTP/RRT adapter using the AKernel-aligned `0.10.1.dev18` daily wheel
- install and select `openyuanrong-sandbox` by default, while keeping `openyuanrong-sdk` as an optional backend
- keep PTY, port URL generation, resources, and administration paths backend-neutral
- add Python 3.14 and the pinned Rust RRT runtime to the shared runtime rootfs
- route `/api/sandbox` and the high-priority `/direct` fast path to the frontend
- update package metadata, documentation, CI, release validation, and unit coverage

## Why

AKernel currently exposes a mostly backend-neutral public API, but its implementation directly depends on actor handles and `yr` value types. The new boundary keeps backend-native handles, input/output conversion, lifecycle ownership, capabilities, and failures inside adapters while preserving the public `Sandbox`, `Commands`, and `Filesystem` APIs.

This implements the direction discussed in #10: `openyuanrong-sandbox` is the default dependency and has auto-detection priority. Applications that need the actor backend install the `openyuanrong-sdk` extra and set `AKERNEL_BACKEND=openyuanrong-sdk` before import.

The Python 3.14, Rust RRT, and frontend routing changes from #8 are integrated here so the runtime image and SDK backend work can be reviewed and landed together.

## Review focus

Please focus review on the backend boundary in `sdk/python/akernel_sdk/_backends/base.py` and its adapter implementations, especially:

- ownership between `Backend`, `BackendSession`, and the public facade
- command and filesystem driver granularity
- input/output conversion and exception containment
- capability validation before remote creation
- detached cleanup and deterministic named deletion

## Known differences

The sandbox backend rejects `schedule_timeout=-1`, custom reverse-tunnel ports, and reverse WebSocket forwarding. These remain available through `openyuanrong-sdk`.

`openyuanrong-sandbox==0.10.1.dev18` is currently consumed from a checksum-pinned daily wheel. A satisfying distribution must be published to the configured package index before an `akernel-sdk` release.

## Validation

- 75 unit tests passed with `AKERNEL_BACKEND=openyuanrong-sandbox`
- 75 unit tests passed with `AKERNEL_BACKEND=openyuanrong-sdk`
- Ruff passed
- mypy passed for 19 source files
- wheel and source distribution built successfully
- Twine checks passed
- deployment script syntax and 2 Traefik route regression tests passed
- clean installation matrix passed for default, sandbox alias, actor extra, all extras, and deliberate `--no-deps`
- workflow YAML and `git diff --check` passed

A real compatible frontend/RRT cluster E2E run has not been performed yet.

Closes #10
