### PR TITLE
build(runtime): support Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
 
     steps:
       - name: Check out repository

--- a/builder/config/yr_services.yaml
+++ b/builder/config/yr_services.yaml
@@ -50,3 +50,15 @@
         type: erofs
         root: "/home/yuanrong/yr-runtime-rootfs.img"
         entrypoint: "/__yuanrong/usr/bin/tini-static -- sh /__yuanrong/home/entryfile.sh"
+    py314:
+      runtime: python3.14
+      rootfs:
+        runtime: runsc
+        type: local
+        path: /home/yuanrong/yr-runtime-rootfs.img
+        readonly: false
+        mountpoint: /var/task/code
+      bootstrap:
+        type: erofs
+        root: "/home/yuanrong/yr-runtime-rootfs.img"
+        entrypoint: "/__yuanrong/usr/bin/tini-static -- sh /__yuanrong/home/entryfile.sh"

--- a/builder/runtime.Dockerfile
+++ b/builder/runtime.Dockerfile
@@ -3,11 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG AKERNEL_RUNTIME_BASE_IMAGE=ubuntu:24.04
-ARG UV_VERSION=0.7.13
+ARG UV_VERSION=0.11.32
 ARG PYTHON_310_VERSION=3.10.18
 ARG PYTHON_311_VERSION=3.11.13
 ARG PYTHON_312_VERSION=3.12.11
 ARG PYTHON_313_VERSION=3.13.5
+ARG PYTHON_314_VERSION=3.14.6
 
 FROM ${AKERNEL_RUNTIME_BASE_IMAGE} AS python-runtime-base
 
@@ -16,6 +17,7 @@ ARG PYTHON_310_VERSION
 ARG PYTHON_311_VERSION
 ARG PYTHON_312_VERSION
 ARG PYTHON_313_VERSION
+ARG PYTHON_314_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive \
     UV_CACHE_DIR=/tmp/uv-cache \
@@ -53,7 +55,8 @@ RUN uv python install \
         "${PYTHON_310_VERSION}" \
         "${PYTHON_311_VERSION}" \
         "${PYTHON_312_VERSION}" \
-        "${PYTHON_313_VERSION}"; \
+        "${PYTHON_313_VERSION}" \
+        "${PYTHON_314_VERSION}"; \
     rm -rf "${UV_CACHE_DIR}"
 
 RUN set -eux; \
@@ -61,7 +64,8 @@ RUN set -eux; \
         "3.10:${PYTHON_310_VERSION}" \
         "3.11:${PYTHON_311_VERSION}" \
         "3.12:${PYTHON_312_VERSION}" \
-        "3.13:${PYTHON_313_VERSION}"; do \
+        "3.13:${PYTHON_313_VERSION}" \
+        "3.14:${PYTHON_314_VERSION}"; do \
         py="${spec%%:*}"; \
         version="${spec#*:}"; \
         uv venv "/opt/venv-py${py}" --python "${version}" --seed; \
@@ -82,6 +86,7 @@ ARG PYTHON_310_VERSION
 ARG PYTHON_311_VERSION
 ARG PYTHON_312_VERSION
 ARG PYTHON_313_VERSION
+ARG PYTHON_314_VERSION
 
 RUN mkdir -p /var/task/code /__yuanrong && \
     ln -sfn /home /__yuanrong/home && \
@@ -180,10 +185,31 @@ RUN set -eux; \
         "/opt/python${py}"; \
     rm -rf "${UV_CACHE_DIR:-/tmp/uv-cache}"
 
+RUN set -eux; \
+    py="3.14"; version="${PYTHON_314_VERSION}"; \
+    attempt=1; \
+    while true; do \
+        uv pip install \
+            --no-cache-dir \
+            --index-url "${PIP_INDEX_URL}" \
+            --python "/opt/venv-py${py}/bin/python" \
+            "fastapi==${FASTAPI_VERSION}" \
+            "pydantic==${PYDANTIC_VERSION}" \
+            "uvicorn==${UVICORN_VERSION}" \
+            "openyuanrong_sdk==${OPEN_YR_VERSION}" && break; \
+        if [ "${attempt}" -ge 3 ]; then exit 1; fi; \
+        sleep $((attempt * 5)); \
+        attempt=$((attempt + 1)); \
+    done; \
+    ln -sfn \
+        "uv-python/cpython-${version}-linux-x86_64-gnu/bin/python${py}" \
+        "/opt/python${py}"; \
+    rm -rf "${UV_CACHE_DIR:-/tmp/uv-cache}"
+
 COPY ./builder/scripts/entryfile.sh /home/entryfile.sh
 RUN set -eux; \
     chmod 0755 /home/entryfile.sh; \
-    for py in 3.10 3.11 3.12 3.13; do \
+    for py in 3.10 3.11 3.12 3.13 3.14; do \
         "/opt/venv-py${py}/bin/python" -m compileall -q \
             "/opt/venv-py${py}/lib/python${py}/site-packages"; \
     done

--- a/builder/scripts/entryfile.sh
+++ b/builder/scripts/entryfile.sh
@@ -21,8 +21,11 @@ case "$RUNTIME_ENV" in
     python3.13)
         PY_VERSION=3.13
         ;;
+    python3.14)
+        PY_VERSION=3.14
+        ;;
     *)
-        echo "unsupported YR_LANGUAGE=${RUNTIME_ENV}; supported runtimes: python3.10, python3.11, python3.12, python3.13" >&2
+        echo "unsupported YR_LANGUAGE=${RUNTIME_ENV}; supported runtimes: python3.10, python3.11, python3.12, python3.13, python3.14" >&2
         exit 127
         ;;
 esac

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Distributed Computing",
 ]


### PR DESCRIPTION
Package CPython 3.14 in the runtime rootfs alongside the existing Python versions and update uv to a version that supports the new interpreter.

Register the py314 workload alias, teach the runtime entrypoint to select Python 3.14, and declare Python 3.14 support in the SDK metadata.

RRT runtime integration and Traefik routing are intentionally handled by #14.