### PR TITLE
fix(runtime): align sandbox system file defaults

### DIFF
--- a/deploy/akernel/charts/core/values.yaml
+++ b/deploy/akernel/charts/core/values.yaml
@@ -346,7 +346,7 @@ node:
               "path": "rootfs",
               "readonly": false
           },
-          "hostname": "runsc",
+          "hostname": "akernel",
           "mounts": [
               {
                   "destination": "/proc",
@@ -476,6 +476,7 @@ node:
 
         [plugin.runtime]
         image_lib_dir="/home/akernel/images"
+        resolv_conf_path="/etc/resolv_akernel.conf"
         # filestore_dir must reside on an XFS filesystem with reflink support.
         # sandboxd will automatically create an XFS image at /home/akernel/xfs.img
         # and mount it here if the mount point does not already exist as XFS.

--- a/deploy/standalone/config/config.json
+++ b/deploy/standalone/config/config.json
@@ -199,7 +199,7 @@
         "path": "rootfs",
         "readonly": false
     },
-    "hostname": "runsc",
+    "hostname": "akernel",
     "mounts": [
         {
             "destination": "/proc",

--- a/deploy/standalone/config/sandboxd_config.toml
+++ b/deploy/standalone/config/sandboxd_config.toml
@@ -28,6 +28,7 @@ enable_cache_in_stock_mode=true
 
 [plugin.runtime]
 image_lib_dir="/home/akernel/images"
+resolv_conf_path="/etc/resolv.conf"
 # filestore_dir must reside on an XFS filesystem with reflink support.
 # sandboxd will automatically create an XFS image at /home/akernel/xfs.img
 # and mount it here if the mount point does not already exist as XFS.


### PR DESCRIPTION
Configure the resolver source used by sandboxd for both runsc and Kata and make the AKernel base OCI hostname match the generated hostname file. Update the sandboxd revision to use common system file preparation.