### PR TITLE
feat(observability): collect process system metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,9 +387,9 @@ python sdk/python/benchmarks/sandbox_pressure.py \
   in the same change so future agents receive current guidance.
 - Use Conventional Commits with a concise title and a prose body explaining
   what changed and why; do not create title-only commits. Keep a blank line
-  between title and body, wrap the body for terminal readability, and sign
-  commits with `git commit -s` to include the Developer Certificate of Origin
-  sign-off.
+  between title and body, limit every commit-message line to 72 characters,
+  and sign commits with `git commit -s` to include the Developer Certificate
+  of Origin sign-off. Mechanically check line lengths before pushing.
 - Keep unrelated dirty files out of commits, especially local deployment state,
   generated binaries, Terraform state, kubeconfigs, tokens, and private
   registry configuration.

--- a/builder/config/otel-collector-config.yaml
+++ b/builder/config/otel-collector-config.yaml
@@ -26,6 +26,55 @@ receivers:
       http:
         endpoint: 0.0.0.0:4318
 
+  # ──────────────────────────────────────────────────────────────────────
+  # hostmetrics/process: system metrics for long-lived AKernel/YuanRong processes
+  # Linux exposes process names through /proc/<pid>/status and truncates them
+  # to 15 characters, hence the optional suffixes below. Per-sandbox runsc
+  # processes are deliberately excluded to keep metric cardinality bounded.
+  # ─────────────────────────────────────────────────────────────────────
+  hostmetrics/process:
+    collection_interval: 15s
+    scrapers:
+      process:
+        include:
+          names:
+            - '^(function_(master|proxy)|datasystem_work(er)?|goruntime|meta_service|iam_server|sandboxd|distill_fs|etcd|otelcol-contrib)$'
+          match_type: regexp
+        scrape_process_delay: 10s
+        mute_process_all_errors: true
+        resource_attributes:
+          process.parent_pid:
+            enabled: false
+          process.executable.path:
+            enabled: false
+          process.command:
+            enabled: false
+          process.command_line:
+            # Used transiently by transform/process_component to distinguish
+            # frontend and scheduler goruntime processes, then removed before export.
+            enabled: true
+          process.owner:
+            enabled: false
+        metrics:
+          process.cpu.time:
+            enabled: true
+          process.cpu.utilization:
+            enabled: true
+          process.memory.usage:
+            enabled: true
+          process.memory.virtual:
+            enabled: true
+          process.memory.utilization:
+            enabled: true
+          process.disk.io:
+            enabled: false
+          process.open_file_descriptors:
+            enabled: true
+          process.threads:
+            enabled: true
+          process.uptime:
+            enabled: true
+
   # ─────────────────────────────────────────────────────────────────────
   # filelog/spdlog: C++ glog-style logs
   # ─────────────────────────────────────────────────────────────────────
@@ -373,6 +422,36 @@ processors:
         value: ${env:AKERNEL_ENV:-default}
         action: upsert
 
+  resource/process_context:
+    attributes:
+      - key: service.name
+        value: akernel-process
+        action: upsert
+      - key: service.instance.id
+        value: ${env:POD_NAME:-unknown}
+        action: upsert
+      - key: akernel_role
+        value: ${env:AKERNEL_ROLE:-unknown}
+        action: upsert
+      - key: k8s.pod.name
+        value: ${env:POD_NAME:-unknown}
+        action: upsert
+      - key: k8s.namespace.name
+        value: ${env:POD_NAMESPACE:-default}
+        action: upsert
+      - key: k8s.node.name
+        value: ${env:NODE_NAME:-unknown}
+        action: upsert
+
+  transform/process_component:
+    error_mode: ignore
+    metric_statements:
+      - 'set(resource.attributes["component.name"], resource.attributes["process.executable.name"])'
+      - 'set(resource.attributes["component.name"], "ds_worker") where IsMatch(resource.attributes["process.executable.name"], "^datasystem_work(er)?$")'
+      - 'set(resource.attributes["component.name"], "frontend") where resource.attributes["process.executable.name"] == "goruntime" and IsMatch(resource.attributes["process.command_line"], "(^|\\s)-runtimeId=frontend_libruntime(\\s|$)")'
+      - 'set(resource.attributes["component.name"], "scheduler") where resource.attributes["process.executable.name"] == "goruntime" and IsMatch(resource.attributes["process.command_line"], "(^|\\s)-runtimeId=scheduler_libruntime(\\s|$)")'
+      - 'delete_key(resource.attributes, "process.command_line")'
+
 exporters:
   otlphttp/loki:
     endpoint: http://${env:LOKI_ENDPOINT:-loki:3100}/otlp
@@ -416,4 +495,8 @@ service:
     metrics:
       receivers: [otlp]
       processors: [memory_limiter, resource, batch]
+      exporters: [prometheusremotewrite]
+    metrics/process:
+      receivers: [hostmetrics/process]
+      processors: [memory_limiter, resource, resource/process_context, transform/process_component, batch]
       exporters: [prometheusremotewrite]

--- a/builder/systemd_services/otel_collector.service
+++ b/builder/systemd_services/otel_collector.service
@@ -9,7 +9,7 @@ Type=simple
 # memory-limiter threshold so GC can react before telemetry is refused.
 Environment=GOMAXPROCS=8
 Environment=GOMEMLIMIT=1400MiB
-PassEnvironment=AKERNEL_ENV YR_LOG_PATH PROMETHEUS_ENDPOINT LOKI_ENDPOINT TEMPO_ENDPOINT
+PassEnvironment=AKERNEL_ENV AKERNEL_ROLE NODE_NAME POD_NAME POD_NAMESPACE YR_LOG_PATH PROMETHEUS_ENDPOINT LOKI_ENDPOINT TEMPO_ENDPOINT
 ExecStartPre=/bin/bash -c 'for i in 1 2 3 4 5; do [ -f /etc/otel-collector/otel_config.yaml ] && break; sleep 1; done; [ -f /etc/otel-collector/otel_config.yaml ] && ln -sf /etc/otel-collector/otel_config.yaml /home/yuanrong/otel_config.yaml || true'
 ExecStart=/usr/local/bin/otelcol-contrib --config=/home/yuanrong/otel_config.yaml
 ExecReload=/bin/kill -HUP $MAINPID

--- a/deploy/akernel/charts/core/files/otel-collector/config.yaml
+++ b/deploy/akernel/charts/core/files/otel-collector/config.yaml
@@ -27,6 +27,55 @@ receivers:
         endpoint: 0.0.0.0:4318
 
   # ─────────────────────────────────────────────────────────────────────
+  # hostmetrics/process: system metrics for long-lived AKernel/YuanRong processes
+  # Linux exposes process names through /proc/<pid>/status and truncates them
+  # to 15 characters, hence the optional suffixes below. Per-sandbox runsc
+  # processes are deliberately excluded to keep metric cardinality bounded.
+  # ───────────────────────────────────────────────────────────────────
+  hostmetrics/process:
+    collection_interval: 15s
+    scrapers:
+      process:
+        include:
+          names:
+            - '^(function_(master|proxy)|datasystem_work(er)?|goruntime|meta_service|iam_server|sandboxd|distill_fs|etcd|otelcol-contrib)$'
+          match_type: regexp
+        scrape_process_delay: 10s
+        mute_process_all_errors: true
+        resource_attributes:
+          process.parent_pid:
+            enabled: false
+          process.executable.path:
+            enabled: false
+          process.command:
+            enabled: false
+          process.command_line:
+            # Used transiently by transform/process_component to distinguish
+            # frontend and scheduler goruntime processes, then removed before export.
+            enabled: true
+          process.owner:
+            enabled: false
+        metrics:
+          process.cpu.time:
+            enabled: true
+          process.cpu.utilization:
+            enabled: true
+          process.memory.usage:
+            enabled: true
+          process.memory.virtual:
+            enabled: true
+          process.memory.utilization:
+            enabled: true
+          process.disk.io:
+            enabled: false
+          process.open_file_descriptors:
+            enabled: true
+          process.threads:
+            enabled: true
+          process.uptime:
+            enabled: true
+
+  # ─────────────────────────────────────────────────────────────────────
   # filelog/spdlog: C++ glog-style logs
   # ─────────────────────────────────────────────────────────────────────
   filelog/spdlog:
@@ -369,6 +418,36 @@ processors:
         value: ${env:AKERNEL_ENV:-default}
         action: upsert
 
+  resource/process_context:
+    attributes:
+      - key: service.name
+        value: akernel-process
+        action: upsert
+      - key: service.instance.id
+        value: ${env:POD_NAME:-unknown}
+        action: upsert
+      - key: akernel_role
+        value: ${env:AKERNEL_ROLE:-unknown}
+        action: upsert
+      - key: k8s.pod.name
+        value: ${env:POD_NAME:-unknown}
+        action: upsert
+      - key: k8s.namespace.name
+        value: ${env:POD_NAMESPACE:-default}
+        action: upsert
+      - key: k8s.node.name
+        value: ${env:NODE_NAME:-unknown}
+        action: upsert
+
+  transform/process_component:
+    error_mode: ignore
+    metric_statements:
+      - 'set(resource.attributes["component.name"], resource.attributes["process.executable.name"])'
+      - 'set(resource.attributes["component.name"], "ds_worker") where IsMatch(resource.attributes["process.executable.name"], "^datasystem_work(er)?$")'
+      - 'set(resource.attributes["component.name"], "frontend") where resource.attributes["process.executable.name"] == "goruntime" and IsMatch(resource.attributes["process.command_line"], "(^|\\s)-runtimeId=frontend_libruntime(\\s|$)")'
+      - 'set(resource.attributes["component.name"], "scheduler") where resource.attributes["process.executable.name"] == "goruntime" and IsMatch(resource.attributes["process.command_line"], "(^|\\s)-runtimeId=scheduler_libruntime(\\s|$)")'
+      - 'delete_key(resource.attributes, "process.command_line")'
+
 exporters:
   otlphttp/loki:
     endpoint: http://${env:LOKI_ENDPOINT:-loki:3100}/otlp
@@ -412,4 +491,8 @@ service:
     metrics:
       receivers: [otlp]
       processors: [memory_limiter, resource, batch]
+      exporters: [prometheusremotewrite]
+    metrics/process:
+      receivers: [hostmetrics/process]
+      processors: [memory_limiter, resource, resource/process_context, transform/process_component, batch]
       exporters: [prometheusremotewrite]

--- a/deploy/akernel/charts/core/templates/frontend/akernel_frontend.yaml
+++ b/deploy/akernel/charts/core/templates/frontend/akernel_frontend.yaml
@@ -89,6 +89,21 @@ spec:
           env:
             - name: AKERNEL_ROLE
               value: "frontend"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
             - name: LITEBUS_DATA_KEY
               valueFrom:
                 secretKeyRef:

--- a/deploy/akernel/charts/core/templates/master/akernel_master.yaml
+++ b/deploy/akernel/charts/core/templates/master/akernel_master.yaml
@@ -79,6 +79,21 @@ spec:
           env:
             - name: AKERNEL_ROLE
               value: "master"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
             {{- if .Values.frontend.enabled }}
             - name: ENABLE_FAAS_FRONTEND
               value: "false"

--- a/deploy/akernel/charts/monitor/dashboards/akernel-process-resources.json
+++ b/deploy/akernel/charts/monitor/dashboards/akernel-process-resources.json
@@ -1,0 +1,511 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "AKernel component CPU, memory, file descriptor, thread, and uptime metrics collected by the OTel process receiver.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "CPU utilization summed across process states.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "min": 0,
+          "max": 1,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (k8s_node_name, k8s_pod_name, component_name) (process_cpu_utilization_ratio{job=\"akernel-process\",akernel_env=~\"$akernel_env\",k8s_node_name=~\"$k8s_node_name\",k8s_pod_name=~\"$k8s_pod_name\",akernel_role=~\"$akernel_role\",component_name=~\"$component_name\"})",
+          "legendFormat": "{{k8s_node_name}} / {{k8s_pod_name}} / {{component_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU utilization by component",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Resident physical memory reported by each process.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "min": 0,
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (k8s_node_name, k8s_pod_name, component_name) (process_memory_usage_bytes{job=\"akernel-process\",akernel_env=~\"$akernel_env\",k8s_node_name=~\"$k8s_node_name\",k8s_pod_name=~\"$k8s_pod_name\",akernel_role=~\"$akernel_role\",component_name=~\"$component_name\"})",
+          "legendFormat": "{{k8s_node_name}} / {{k8s_pod_name}} / {{component_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Resident memory by component",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Open file descriptors currently held by each process.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (k8s_node_name, k8s_pod_name, component_name) (process_open_file_descriptors{job=\"akernel-process\",akernel_env=~\"$akernel_env\",k8s_node_name=~\"$k8s_node_name\",k8s_pod_name=~\"$k8s_pod_name\",akernel_role=~\"$akernel_role\",component_name=~\"$component_name\"})",
+          "legendFormat": "{{k8s_node_name}} / {{k8s_pod_name}} / {{component_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Open file descriptors by component",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Thread count reported by each process.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (k8s_node_name, k8s_pod_name, component_name) (process_threads{job=\"akernel-process\",akernel_env=~\"$akernel_env\",k8s_node_name=~\"$k8s_node_name\",k8s_pod_name=~\"$k8s_pod_name\",akernel_role=~\"$akernel_role\",component_name=~\"$component_name\"})",
+          "legendFormat": "{{k8s_node_name}} / {{k8s_pod_name}} / {{component_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Threads by component",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Seconds since each process started.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "min"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (k8s_node_name, k8s_pod_name, component_name) (process_uptime_seconds{job=\"akernel-process\",akernel_env=~\"$akernel_env\",k8s_node_name=~\"$k8s_node_name\",k8s_pod_name=~\"$k8s_pod_name\",akernel_role=~\"$akernel_role\",component_name=~\"$component_name\"})",
+          "legendFormat": "{{k8s_node_name}} / {{k8s_pod_name}} / {{component_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Process uptime",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Current resident memory snapshot for the selected components.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true
+          },
+          "mappings": [],
+          "noValue": "N/A",
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Value"
+          }
+        ]
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "topk(50, sum by (k8s_node_name, k8s_pod_name, akernel_role, component_name) (process_memory_usage_bytes{job=\"akernel-process\",akernel_env=~\"$akernel_env\",k8s_node_name=~\"$k8s_node_name\",k8s_pod_name=~\"$k8s_pod_name\",akernel_role=~\"$akernel_role\",component_name=~\"$component_name\"}))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Current resident memory snapshot",
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "refresh": "15s",
+  "schemaVersion": 42,
+  "tags": [
+    "akernel",
+    "otel",
+    "process",
+    "resources",
+    "cpu",
+    "memory",
+    "file-descriptors"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(process_memory_usage_bytes{job=\"akernel-process\"}, akernel_env)",
+        "includeAll": true,
+        "label": "Environment",
+        "multi": true,
+        "name": "akernel_env",
+        "options": [],
+        "query": {
+          "query": "label_values(process_memory_usage_bytes{job=\"akernel-process\"}, akernel_env)",
+          "refId": "Prometheus-akernel-env-Variable"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(process_memory_usage_bytes{job=\"akernel-process\",akernel_env=~\"$akernel_env\"}, k8s_node_name)",
+        "includeAll": true,
+        "label": "Node",
+        "multi": true,
+        "name": "k8s_node_name",
+        "options": [],
+        "query": {
+          "query": "label_values(process_memory_usage_bytes{job=\"akernel-process\",akernel_env=~\"$akernel_env\"}, k8s_node_name)",
+          "refId": "Prometheus-node-Variable"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(process_memory_usage_bytes{job=\"akernel-process\",akernel_env=~\"$akernel_env\",k8s_node_name=~\"$k8s_node_name\"}, k8s_pod_name)",
+        "includeAll": true,
+        "label": "Pod",
+        "multi": true,
+        "name": "k8s_pod_name",
+        "options": [],
+        "query": {
+          "query": "label_values(process_memory_usage_bytes{job=\"akernel-process\",akernel_env=~\"$akernel_env\",k8s_node_name=~\"$k8s_node_name\"}, k8s_pod_name)",
+          "refId": "Prometheus-pod-Variable"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(process_memory_usage_bytes{job=\"akernel-process\",akernel_env=~\"$akernel_env\",k8s_node_name=~\"$k8s_node_name\",k8s_pod_name=~\"$k8s_pod_name\"}, akernel_role)",
+        "includeAll": true,
+        "label": "Role",
+        "multi": true,
+        "name": "akernel_role",
+        "options": [],
+        "query": {
+          "query": "label_values(process_memory_usage_bytes{job=\"akernel-process\",akernel_env=~\"$akernel_env\",k8s_node_name=~\"$k8s_node_name\",k8s_pod_name=~\"$k8s_pod_name\"}, akernel_role)",
+          "refId": "Prometheus-role-Variable"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(process_memory_usage_bytes{job=\"akernel-process\",akernel_env=~\"$akernel_env\",k8s_node_name=~\"$k8s_node_name\",k8s_pod_name=~\"$k8s_pod_name\",akernel_role=~\"$akernel_role\"}, component_name)",
+        "includeAll": true,
+        "label": "Component",
+        "multi": true,
+        "name": "component_name",
+        "options": [],
+        "query": {
+          "query": "label_values(process_memory_usage_bytes{job=\"akernel-process\",akernel_env=~\"$akernel_env\",k8s_node_name=~\"$k8s_node_name\",k8s_pod_name=~\"$k8s_pod_name\",akernel_role=~\"$akernel_role\"}, component_name)",
+          "refId": "Prometheus-component-Variable"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "AKernel Process Resources",
+  "uid": "akernel-process-resources",
+  "version": 1
+}

--- a/deploy/standalone/start.sh
+++ b/deploy/standalone/start.sh
@@ -265,6 +265,7 @@ start_node_container() {
         --privileged \
         --net bridge \
         --restart always \
+        -e AKERNEL_ROLE="standalone" \
         -e AKS_LOCAL_MODE="true" \
         -e TRAEFIK_MODE="etcd" \
         -e TRAEFIK_HTTP_ENTRYPOINT="web" \


### PR DESCRIPTION
## What changed

- add an OpenTelemetry `hostmetrics/process` pipeline for long-lived AKernel and YuanRong processes
- collect CPU time/utilization, RSS/virtual memory, memory utilization, open file descriptors, thread count, and uptime every 15 seconds
- attach environment, role, pod, namespace, node, process, and normalized component resource attributes before Prometheus remote write
- normalize the truncated DataSystem process name to `component_name="ds_worker"`
- distinguish `goruntime` as `frontend` or `scheduler` from its stable runtime ID, then remove `process.command_line` before export
- pass pod and node identity into the collector for master, frontend, node, and standalone deployments
- provision an `AKernel Process Resources` Grafana dashboard with environment, node, Pod, role, and component filters

## Dashboard

The dashboard provides six panels:

- CPU utilization by component
- resident memory by component
- open file descriptors by component
- thread count by component
- process uptime
- current resident-memory snapshot

## Why

The collector previously accepted metrics pushed by applications but did not report operating-system resource usage for individual platform components. This left CPU, memory, file descriptor, thread, and uptime visibility unavailable at the component and node level.

The process allowlist intentionally excludes per-sandbox `runsc` processes to avoid unbounded time-series cardinality.

## Validation

- validated both collector configurations with `otel/opentelemetry-collector-contrib:0.120.0`
- verified remote write end to end with shared-PID-namespace frontend, scheduler, and DataSystem test processes; Prometheus received `frontend`, `scheduler`, and `ds_worker`, with no command-line label exported
- parsed every dashboard JSON and all six new PromQL expressions with Prometheus 3.5.0 `promtool`
- provisioned the dashboard into Grafana 11.5.2 and verified its UID, title, and six panels through the Grafana API
- `make SHELL=/bin/bash deploy-script-check`
- Helm 3.18.4 lint and template rendering for the core and monitor charts
- `git diff --check`
