### PR TITLE
fix: make examples work with the default RRT runtime

### DIFF
--- a/sdk/python/examples/network_policy.py
+++ b/sdk/python/examples/network_policy.py
@@ -19,25 +19,22 @@ import shlex
 from akernel_sdk import NetworkPolicy, Sandbox
 
 
-def dns_lookup(domain: str) -> str:
-    program = "import socket,sys; print(socket.getaddrinfo(sys.argv[1], 443)[0][4][0])"
-    return f"python3 -c {shlex.quote(program)} {shlex.quote(domain)}"
+def tcp_connection(host: str, port: int) -> str:
+    program = f"exec 3<>/dev/tcp/{shlex.quote(host)}/{port}"
+    return f"bash -c {shlex.quote(program)}"
 
 
 def direct_connection() -> str:
-    program = (
-        "import socket; "
-        "connection=socket.create_connection(('1.1.1.1', 53), 3); "
-        "connection.close()"
-    )
-    return f"python3 -c {shlex.quote(program)}"
+    return tcp_connection("1.1.1.1", 53)
 
 
 def main() -> None:
     with Sandbox() as unrestricted:
-        result = unrestricted.commands.run(dns_lookup("github.com"), timeout=30)
+        result = unrestricted.commands.run(
+            tcp_connection("github.com", 443), timeout=30
+        )
         assert result.exit_code == 0, result.stderr
-        print(f"Unrestricted DNS result: {result.stdout.strip()}")
+        print("Unrestricted DNS and connection succeeded.")
 
     with Sandbox(network_policy=NetworkPolicy.block()) as blocked:
         control = blocked.commands.run("printf 'control plane works'")
@@ -53,12 +50,16 @@ def main() -> None:
 
     dns_policy = NetworkPolicy.deny_dns("github.com", "*.github.com")
     with Sandbox(network_policy=dns_policy) as dns_filtered:
-        denied = dns_filtered.commands.run(dns_lookup("github.com"), timeout=30)
+        denied = dns_filtered.commands.run(
+            tcp_connection("github.com", 443), timeout=30
+        )
         assert denied.exit_code != 0
 
-        allowed = dns_filtered.commands.run(dns_lookup("example.com"), timeout=30)
+        allowed = dns_filtered.commands.run(
+            tcp_connection("example.com", 443), timeout=30
+        )
         assert allowed.exit_code == 0, allowed.stderr
-        print(f"Allowed DNS result: {allowed.stdout.strip()}")
+        print("Allowed DNS and connection succeeded.")
 
 
 if __name__ == "__main__":

--- a/sdk/python/examples/port_forwarding.py
+++ b/sdk/python/examples/port_forwarding.py
@@ -14,12 +14,14 @@
 
 """Expose an HTTP server running in a sandbox through AKernel's gateway."""
 
+import os
 import time
 import urllib.request
 
 from akernel_sdk import Sandbox
 
 PORT = 8080
+IMAGE = os.environ.get("AKERNEL_PORT_FORWARDING_IMAGE", "python:3.12-slim")
 
 
 def fetch_with_retry(url: str, timeout: float = 30.0) -> str:
@@ -37,6 +39,7 @@ def fetch_with_retry(url: str, timeout: float = 30.0) -> str:
 
 def main() -> None:
     with Sandbox(
+        image=IMAGE,
         cpu=1000,
         memory=2048,
         port_forwardings=[PORT],

--- a/sdk/python/examples/reverse_tunnel.py
+++ b/sdk/python/examples/reverse_tunnel.py
@@ -57,15 +57,19 @@ def main() -> None:
             reverse_tunnel=tunnel,
         ) as sandbox:
             probe = (
-                "import sys,urllib.request;"
-                "response=urllib.request.urlopen(sys.argv[1],timeout=10);"
-                "print(response.read().decode().strip())"
+                "exec 3<>/dev/tcp/127.0.0.1/8766; "
+                "printf 'GET /health HTTP/1.1\\r\\nHost: 127.0.0.1\\r\\n"
+                "Connection: close\\r\\n\\r\\n' >&3; "
+                "while IFS= read -r line <&3; do "
+                "case \"$line\" in "
+                "*AKERNEL_REVERSE_TUNNEL_OK*) "
+                "printf 'AKERNEL_REVERSE_TUNNEL_OK\\n'; exit 0;; "
+                "esac; "
+                "done; "
+                "exit 1"
             )
             result = sandbox.commands.run(
-                "python3 -c "
-                + shlex.quote(probe)
-                + " "
-                + shlex.quote(f"{sandbox.reverse_tunnel.url}/health"),
+                "bash -c " + shlex.quote(probe),
                 timeout=20,
             )
             assert result.exit_code == 0, result.stderr


### PR DESCRIPTION
Use Bash's built-in TCP support for the reverse tunnel and network policy probes so they no longer assume Python exists in the default sandbox rootfs. Select a Python image explicitly for port forwarding because that example intentionally starts a Python HTTP server.

This keeps Python optional while preserving the example workflows on the default RRT-only runtime profile.