### PR TITLE
fix(sdk): default gateway to plain HTTP

### DIFF
--- a/sdk/python/akernel_sdk/_addresses.py
+++ b/sdk/python/akernel_sdk/_addresses.py
@@ -16,8 +16,8 @@
 
 The public SDK accepts a compact ``AKERNEL_SERVER_ADDRESS`` value:
 
-* ``host``: public mode.  Frontend API and exec WebSocket use 443/TLS; public
-  port-forward URLs use 80/plain HTTP.
+* ``host:port``: shared-port mode.  Frontend API and exec WebSocket use the
+  explicit port with TLS; public port-forward URLs use it with plain HTTP.
 * ``host:port``: shared-port mode.  Frontend API, exec WebSocket, and public
   port-forward URLs all use the explicit port with TLS by default.
 
@@ -123,7 +123,7 @@ def gateway_endpoint_from_env() -> Endpoint:
     An explicit gateway override is parsed as plain HTTP by default because
     standalone exposes Traefik's web entrypoint without TLS.  Without an
     explicit gateway, host-only server addresses use public 80, while
-    host:port server addresses share the API port and TLS setting.
+    host:port server addresses reuse the API port with plain HTTP.
     """
     override = _gateway_override_raw()
     if override:
@@ -138,7 +138,7 @@ def gateway_endpoint_from_env() -> Endpoint:
         return Endpoint(
             host=server.host,
             port=server.port,
-            scheme=server.scheme,
+            scheme="http",
             explicit_port=True,
         )
     return Endpoint(

--- a/sdk/python/tests/unit/test_addresses.py
+++ b/sdk/python/tests/unit/test_addresses.py
@@ -43,14 +43,15 @@ class AddressConfigTest(unittest.TestCase):
                 ("http", "10.0.0.1", 80, False),
             )
 
-    def test_explicit_server_port_is_shared_tls_port(self):
+    def test_explicit_server_port_uses_plain_http_gateway(self):
         with patch.dict(
             os.environ, {"AKERNEL_SERVER_ADDRESS": "10.0.0.1:8888"}, clear=True
         ):
             expected = ("https", "10.0.0.1", 8888, True)
+            gateway_expected = ("http", "10.0.0.1", 8888, False)
             self.assertEqual(endpoint_tuple(api_endpoint_from_env()), expected)
             self.assertEqual(endpoint_tuple(exec_endpoint_from_env()), expected)
-            self.assertEqual(endpoint_tuple(gateway_endpoint_from_env()), expected)
+            self.assertEqual(endpoint_tuple(gateway_endpoint_from_env()), gateway_expected)
 
     def test_gateway_override_defaults_to_plain_http(self):
         with patch.dict(


### PR DESCRIPTION
Default gateway endpoints derived from an explicit server port now use plain HTTP while preserving the server host and port. This keeps API and exec traffic on TLS and lets deployments enable gateway TLS explicitly through the AKERNEL_GATEWAY_ADDRESS scheme.

Update address tests to cover shared-port HTTP gateway behavior.