### PR TITLE
fix(sdk): close backend resources before sandbox deletion

### DIFF
--- a/sdk/python/akernel_sdk/_backends/openyuanrong_sandbox.py
+++ b/sdk/python/akernel_sdk/_backends/openyuanrong_sandbox.py
@@ -249,9 +249,12 @@ class _Session:
     def terminate(self) -> None:
         if self._terminated:
             return
+        # Release the native handle before deleting the remote sandbox. This
+        # lets transports such as reverse tunnels close while their routes are
+        # still available. The stable-ID delete still uses a fresh native
+        # client, so a failed deletion remains retryable after local cleanup.
+        self.close()
         try:
-            # The native instance is one-shot: kill() closes its HTTP client even
-            # when deletion fails. Delete by stable ID so a retry gets a new client.
             yr_sandbox.Sandbox.delete(self.id)
         except Exception as error:
             raise _convert_error("terminate sandbox", error) from error

--- a/sdk/python/tests/unit/test_backends.py
+++ b/sdk/python/tests/unit/test_backends.py
@@ -313,6 +313,26 @@ class OpenYuanRongSandboxBackendTest(unittest.TestCase):
         native.close.assert_called_once_with()
         native.kill.assert_not_called()
 
+    def test_terminate_closes_native_resources_before_remote_delete(self):
+        lifecycle = []
+        native = MagicMock()
+        native.id = "default-worker"
+        native.commands = MagicMock()
+        native.files = MagicMock()
+        native.close.side_effect = lambda: lifecycle.append("close")
+        with patch.object(
+            openyuanrong_sandbox.yr_sandbox,
+            "Sandbox",
+            return_value=native,
+        ) as sandbox_type:
+            sandbox_type.delete.side_effect = lambda _sandbox_id: lifecycle.append(
+                "delete"
+            )
+            session = self.backend.create(_spec())
+            session.terminate()
+
+        self.assertEqual(lifecycle, ["close", "delete"])
+
     def test_detached_delete_failure_still_allows_local_cleanup(self):
         native = MagicMock()
         native.id = "default-worker"


### PR DESCRIPTION
Close the native openYuanRong sandbox handle before issuing the stable-ID remote delete. This lets local transports shut down while their remote routes still exist and prevents lifecycle cleanup from waiting through transport reconnect timeouts.

Keep the remote delete on a fresh native client so failures remain retryable after local cleanup, and cover the ordering contract with a backend unit test.