### PR TITLE
feat: adopt portable loop-backed filestores and add E2E test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sdk-unit-tests:
     name: Python SDK unit tests (${{ matrix.python-version }})
@@ -63,3 +67,110 @@ jobs:
         run: |
           unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY no_proxy NO_PROXY
           make deploy-script-check
+
+  standalone-e2e:
+    name: Standalone E2E
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize build submodules
+        run: |
+          unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY no_proxy NO_PROXY
+          git submodule update --init src/sandboxd src/distill-fs
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: sdk/python/pyproject.toml
+
+      - name: Install SDK dependencies
+        run: |
+          unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY no_proxy NO_PROXY
+          python -m pip install -e './sdk/python[all]'
+
+      - name: Prepare host kernel modules
+        run: |
+          unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY no_proxy NO_PROXY
+          sudo modprobe loop
+          sudo modprobe erofs
+          sudo modprobe br_netfilter
+          sudo sysctl -w net.bridge.bridge-nf-call-iptables=1
+
+      - name: Build all-in-one image
+        run: |
+          unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY no_proxy NO_PROXY
+          AKERNEL_ENABLE_KATA=false \
+            make build \
+              IMAGE_REPOSITORY=akernel-ci/all-in-one \
+              IMAGE_TAG="${GITHUB_SHA}" \
+              RUNTIME_PROFILE=rrt
+
+      - name: Start standalone AKernel
+        run: |
+          unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY no_proxy NO_PROXY
+          IMAGE="akernel-ci/all-in-one:${GITHUB_SHA}" \
+            AKERNEL_NAT_BACKEND=iptables \
+            ./deploy/standalone/start.sh
+
+      - name: Run SDK end-to-end examples
+        run: |
+          unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY no_proxy NO_PROXY
+          gateway_ip="$(docker inspect \
+            --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' \
+            akernel-traefik)"
+          test -n "${gateway_ip}"
+          token="$(cat deploy/standalone/data/token)"
+          export AKERNEL_TOKEN="${token}"
+          export AKERNEL_SERVER_ADDRESS="${gateway_ip}"
+          export PYTHONPATH="${GITHUB_WORKSPACE}/sdk/python"
+
+          examples=(
+            basic_usage.py
+            command_stdin.py
+            custom_image.py
+            named_sandbox.py
+            network_policy.py
+            port_forwarding.py
+            pty.py
+            reverse_tunnel.py
+            storage_sandbox.py
+          )
+          for example in "${examples[@]}"; do
+            echo "=== Running ${example} ==="
+            timeout 120s python "sdk/python/examples/${example}"
+          done
+
+      - name: Show standalone diagnostics
+        if: failure()
+        run: |
+          unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY no_proxy NO_PROXY
+          docker ps -a
+          for container in akernel-node akernel-traefik; do
+            if docker container inspect "${container}" >/dev/null 2>&1; then
+              echo "=== ${container}: docker logs ==="
+              docker logs --tail 500 "${container}" 2>&1 || true
+            fi
+          done
+          if docker container inspect akernel-node >/dev/null 2>&1; then
+            echo "=== akernel-node: service journal ==="
+            docker exec akernel-node journalctl --no-pager -n 500 \
+              -u sandboxd.service -u yuanrong.service || true
+          fi
+
+      - name: Stop standalone AKernel
+        if: always()
+        run: |
+          unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY no_proxy NO_PROXY
+          if [[ -x ./deploy/standalone/stop.sh ]]; then
+            ./deploy/standalone/stop.sh
+          else
+            docker rm -f akernel-traefik akernel-node >/dev/null 2>&1 || true
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,7 +317,7 @@ the sandbox bridge. YuanRong receives `INSTANCE_IP` in Kubernetes or the
 default-route interface address in standalone mode; `AKERNEL_NODE_IP` is the
 explicit override for multi-homed environments.
 
-The standalone sandboxd filestore is a loop-mounted XFS image under the
+The standalone sandboxd filestore is a loop-mounted ext4 image under the
 bind-mounted `deploy/standalone/data/` directory. Explicit `storage_mb` quotas
 use this local-disk filestore; omitting `storage_mb` retains the configured
 memory-backed writable overlay.

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ help:
 	@echo "  make config INSTALL_DRAGONFLY=true Enable optional P2P image distribution"
 	@echo "  make build IMAGE_TAG=<tag>          Build the all-in-one image"
 	@echo "  make build RUNTIME_PROFILE=python   Include optional Python runtimes"
+	@echo "  make build AKERNEL_ENABLE_KATA=false Exclude the optional Kata payload"
 	@echo "  make build GVISOR_RELEASE=<tag>     Override the pinned official gVisor tag"
 	@echo "  make versions                       Show locally selected component versions"
 	@echo "  make push                          Push the configured all-in-one image"

--- a/builder/node.Dockerfile
+++ b/builder/node.Dockerfile
@@ -5,6 +5,7 @@
 ARG AKERNEL_NODE_BASE_IMAGE=ubuntu:24.04
 ARG AKERNEL_RUNTIME_IMAGE=akernel-runtime:local
 ARG AKERNEL_RUNTIME_PROFILE=rrt
+ARG AKERNEL_ENABLE_KATA=true
 ARG SANDBOXD_BUILD_IMAGE=golang:1.25.5-bookworm
 ARG DISTILL_FS_BUILD_IMAGE=rust:1.85.0-bookworm
 ARG OPEN_YR_VERSION=0.9.7
@@ -25,7 +26,7 @@ ARG OTELCOL_CONTRIB_URL=https://github.com/open-telemetry/opentelemetry-collecto
 ARG AKERNEL_VERSION=unknown
 ARG AKERNEL_REVISION=unknown
 
-FROM ${KATA_BUILD_IMAGE} AS kata-runtime
+FROM ${KATA_BUILD_IMAGE} AS kata-runtime-true
 ARG KATA_RELEASE
 ARG KATA_AMD64_SHA256
 ARG KATA_RELEASE_BASE_URL
@@ -55,6 +56,11 @@ RUN set -eux; \
       "https://raw.githubusercontent.com/kata-containers/kata-containers/${KATA_RELEASE}/LICENSE" \
       -o /kata/opt/kata/share/licenses/kata-containers/LICENSE; \
     rm -f "${archive}"
+
+FROM ${KATA_BUILD_IMAGE} AS kata-runtime-false
+RUN mkdir -p /kata/opt/kata
+
+FROM kata-runtime-${AKERNEL_ENABLE_KATA} AS kata-runtime
 
 FROM ${AKERNEL_RUNTIME_IMAGE} AS runtime-image
 
@@ -91,6 +97,7 @@ COPY ./src/distill-fs/ ./
 RUN cargo build --locked --release --bin distill_fs
 
 FROM ${AKERNEL_NODE_BASE_IMAGE}
+ARG AKERNEL_ENABLE_KATA
 ARG AKERNEL_RUNTIME_PROFILE
 ARG AKERNEL_VERSION
 ARG AKERNEL_REVISION
@@ -242,7 +249,9 @@ COPY --from=sandboxd-builder /src/sandboxd/output/sbox /usr/local/bin/sbox
 COPY --from=sandboxd-builder /src/sandboxd/output/sandbox-logger /usr/local/bin/sandbox-logger
 COPY --from=distill-fs-builder /src/distill-fs/target/release/distill_fs /usr/local/bin/distill_fs
 COPY --from=kata-runtime /kata/opt/kata /opt/kata
-RUN ln -sf /opt/kata/runtime-rs/bin/containerd-shim-kata-v2 /usr/local/bin/containerd-shim-kata-v2
+RUN if [ "${AKERNEL_ENABLE_KATA}" = "true" ]; then \
+      ln -sf /opt/kata/runtime-rs/bin/containerd-shim-kata-v2 /usr/local/bin/containerd-shim-kata-v2; \
+    fi
 
 COPY ./builder/scripts/akernel-entrypoint.sh /usr/local/bin/akernel-entrypoint
 COPY ./builder/scripts/ensure-component-cert.sh /usr/local/bin/ensure-component-cert
@@ -253,10 +262,10 @@ RUN chmod 0755 \
         /usr/local/bin/sbox \
         /usr/local/bin/sandbox-logger \
         /usr/local/bin/distill_fs \
-        /usr/local/bin/containerd-shim-kata-v2 \
         /usr/local/bin/akernel-entrypoint \
         /usr/local/bin/ensure-component-cert \
         /usr/local/bin/sandboxd-network-prepare
+RUN if [ "${AKERNEL_ENABLE_KATA}" = "true" ]; then chmod 0755 /usr/local/bin/containerd-shim-kata-v2; fi
 
 COPY ./builder/config/yr_services.yaml /tmp/yr_services_rrt.yaml
 COPY ./builder/config/yr_services_python.yaml /tmp/yr_services_python.yaml
@@ -295,7 +304,8 @@ RUN mkdir -p ${YR_INSTALLATION_DIR}/logs ${YR_INSTALLATION_DIR}/metrics ${YR_INS
 
 LABEL org.opencontainers.image.version="${AKERNEL_VERSION}" \
       org.opencontainers.image.revision="${AKERNEL_REVISION}" \
-      org.akernel.runtime.profile="${AKERNEL_RUNTIME_PROFILE}"
+      org.akernel.runtime.profile="${AKERNEL_RUNTIME_PROFILE}" \
+      org.akernel.kata.enabled="${AKERNEL_ENABLE_KATA}"
 
 ENV YR_LOG_PATH=${YR_INSTALLATION_DIR}/logs
 STOPSIGNAL SIGRTMIN+3

--- a/deploy/akernel/charts/core/values.yaml
+++ b/deploy/akernel/charts/core/values.yaml
@@ -478,12 +478,12 @@ node:
         [plugin.runtime]
         image_lib_dir="/home/akernel/images"
         resolv_conf_path="/etc/resolv_akernel.conf"
-        # filestore_dir must reside on an XFS filesystem with reflink support.
-        # sandboxd will automatically create an XFS image at /home/akernel/xfs.img
-        # and mount it here if the mount point does not already exist as XFS.
-        # filestore_dir_size controls the size of that XFS image.
-        filestore_dir="/home/akernel/xfs"
+        # A configured size creates a loop-backed bounded filestore. ext4 is
+        # used by default; set filestore_xfs_enabled=true to select XFS.
+        filestore_dir="/home/akernel/filestore"
         filestore_dir_size="200G"
+        filestore_xfs_enabled=false
+        loop_device_dir="/dev"
         overlay_tmpfs_size="10G"
 
         [plugin.runtime.basic_spec]

--- a/deploy/scripts/build-image.sh
+++ b/deploy/scripts/build-image.sh
@@ -114,6 +114,11 @@ case "${runtime_profile}" in
   *) die "unsupported runtime profile: ${runtime_profile}; expected rrt or python" ;;
 esac
 
+case "${AKERNEL_ENABLE_KATA:-true}" in
+  true|false) ;;
+  *) die "AKERNEL_ENABLE_KATA must be true or false" ;;
+esac
+
 require_cmd docker
 
 if [[ -n "${env_name}" && -f "$(state_dir "${env_name}")/config.env" ]]; then
@@ -167,6 +172,7 @@ info "building ${all_in_one_image}"
 node_build_args=(
   --build-arg "AKERNEL_RUNTIME_IMAGE=${runtime_image}"
   --build-arg "AKERNEL_RUNTIME_PROFILE=${runtime_profile}"
+  --build-arg "AKERNEL_ENABLE_KATA=${AKERNEL_ENABLE_KATA:-true}"
   --build-arg "AKERNEL_VERSION=${akernel_version}"
   --build-arg "AKERNEL_REVISION=${akernel_revision}"
 )

--- a/deploy/standalone/README.md
+++ b/deploy/standalone/README.md
@@ -26,9 +26,9 @@ The all-in-one image contains `nvidia-container-cli`, but not the host driver.
 Use `AKERNEL_GPU_DEVICES` to override Docker's `--gpus` value when only a
 device subset should be assigned.
 
-Explicit sandbox storage quotas use the XFS filestore mounted at
-`/home/akernel/xfs`. The standalone data directory is bind-mounted from the
-host, and sandboxd creates `data/xfs.img` as a loop-backed XFS filesystem when
+Explicit sandbox storage quotas use the bounded ext4 filestore mounted at
+`/home/akernel/filestore`. The standalone data directory is bind-mounted from
+the host, and sandboxd creates a loop-backed filesystem image there when
 needed; quota-backed writable layers therefore use local disk rather than
 tmpfs.
 

--- a/deploy/standalone/config/sandboxd_config.toml
+++ b/deploy/standalone/config/sandboxd_config.toml
@@ -31,12 +31,12 @@ enable_cache_in_stock_mode=true
 [plugin.runtime]
 image_lib_dir="/home/akernel/images"
 resolv_conf_path="/etc/resolv.conf"
-# filestore_dir must reside on an XFS filesystem with reflink support.
-# sandboxd will automatically create an XFS image at /home/akernel/xfs.img
-# and mount it here if the mount point does not already exist as XFS.
-# filestore_dir_size controls the size of that XFS image.
-filestore_dir="/home/akernel/xfs"
+# A configured size creates a loop-backed bounded filestore. ext4 is used by
+# default; set filestore_xfs_enabled=true to select XFS.
+filestore_dir="/home/akernel/filestore"
 filestore_dir_size="50G"
+filestore_xfs_enabled=false
+loop_device_dir="/dev"
 overlay_tmpfs_size="10G"
 
 [plugin.runtime.basic_spec]

--- a/deploy/terraform/aliyun/values-akernel.yaml.tmpl
+++ b/deploy/terraform/aliyun/values-akernel.yaml.tmpl
@@ -192,8 +192,10 @@ node:
 
         [plugin.runtime]
         image_lib_dir="/home/akernel/images"
-        filestore_dir="/home/akernel/xfs"
+        filestore_dir="/home/akernel/filestore"
         filestore_dir_size="200G"
+        filestore_xfs_enabled=false
+        loop_device_dir="/dev"
         overlay_tmpfs_size="10G"
 
         [plugin.runtime.basic_spec]

--- a/deploy/terraform/huaweicloud/values-akernel.yaml.tmpl
+++ b/deploy/terraform/huaweicloud/values-akernel.yaml.tmpl
@@ -150,8 +150,10 @@ node:
 
         [plugin.runtime]
         image_lib_dir="/home/akernel/images"
-        filestore_dir="/home/akernel/xfs"
+        filestore_dir="/home/akernel/filestore"
         filestore_dir_size="200G"
+        filestore_xfs_enabled=false
+        loop_device_dir="/dev"
         overlay_tmpfs_size="10G"
 
         [plugin.runtime.basic_spec]

--- a/deploy/terraform/shared/node-bootstrap.sh.tftpl
+++ b/deploy/terraform/shared/node-bootstrap.sh.tftpl
@@ -26,6 +26,27 @@ systemctl enable akernel-network-modules.service
 systemctl start akernel-network-modules.service
 %{ endif ~}
 
+# Bounded sandbox filestores use loop devices. Load the host module before
+# kubelet starts so privileged node containers can allocate loop devices.
+cat >/etc/systemd/system/akernel-loop-module.service <<'EOF'
+[Unit]
+Description=Load loop kernel module for AKernel filestores
+After=systemd-modules-load.service
+Before=kubelet.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'modprobe loop'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable akernel-loop-module.service
+systemctl start akernel-loop-module.service
+
 # Enable user namespaces (required by gVisor/runsc).
 #
 # user_data only runs on first boot, so a plain `sysctl -w` does not survive a


### PR DESCRIPTION
## Summary

Make bounded filestores portable across standalone and Kubernetes
deployments, make the Kata image payload optional, and add an all-in-one SDK
E2E job.

## Changes

- Update sandboxd to `a8fc65646975bcd391dbaac7c0bc9c1a745e2e83`.
- Use loop-backed ext4 filestores by default, with XFS available as an opt-in.
- Load the host loop module during cloud node bootstrap.
- Align standalone, Helm, Aliyun, and HuaweiCloud storage configuration.
- Add `AKERNEL_ENABLE_KATA`; existing builds keep the `true` default.
- Build RRT without Kata in CI, start standalone, and run `basic_usage.py`.
- Print container diagnostics on failure and always clean up CI containers.

## Validation

- sandboxd ext4, XFS, and EROFS loop-device integration tests passed.
- Standalone, Traefik, SDK `basic_usage.py`, and quota storage smoke passed.
- Deployment script checks and Helm rendering passed.
