### PR TITLE
feat: add optional runc support and generic runtime configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,12 @@ project guidance.
 AKernel provides cluster-backed remote sandbox environments for agents and
 developer workflows. The current public user-facing surface is the Python
 `akernel-sdk`, including the `akernel_sdk.Sandbox` API and the `ak` CLI.
-The default sandbox runtime is gVisor runsc. Runtime identifiers are forwarded
-to the selected backend, which owns availability and compatibility checks; the
-bundled deployment also advertises Kata Containers on KVM-capable nodes.
+The default sandbox runtime is gVisor runsc. Runtime identifiers and generic
+JSON-compatible runtime configuration are forwarded to the selected backend,
+which owns availability and compatibility checks; the bundled deployment also
+advertises Kata Containers on KVM-capable nodes. The native Linux runc payload
+is build-time optional and must be explicitly included and enabled by an
+operator.
 Creation-time network policies support unrestricted networking, blocking new
 flows except the YuanRong control and published sandbox-port routes, or denying
 exact and leading-wildcard DNS names.
@@ -284,6 +287,18 @@ Select Kata explicitly only when the cluster has an eligible node:
 ```python
 with Sandbox(runtime="kata", cpu=2000, memory=4096) as sb:
     print(sb.commands.run("uname -s").stdout)
+```
+
+Select an explicitly enabled runc runtime and pass runtime-owned options:
+
+```python
+with Sandbox(
+    runtime="runc",
+    extra_config={"enableKVM": True},
+    cpu=2000,
+    memory=4096,
+) as sb:
+    print(sb.commands.run("test -c /dev/kvm").exit_code)
 ```
 
 Request experimental gVisor GPU and disk-backed writable storage resources:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,9 @@ build tooling, and examples. Node runtime components such as `sandboxd` and
 `distill-fs` are maintained in their own upstream repositories. The all-in-one
 Docker build copies and compiles their pinned Git submodules in dedicated
 builder stages. It also downloads `runsc` from the official gVisor release
-bucket and verifies its published SHA-512 checksum. The node image includes
+bucket and verifies its published SHA-512 checksum. When
+`AKERNEL_ENABLE_RUNC=true`, it also installs a pinned runc release after
+verifying its SHA-256 digest. The node image includes
 the pinned `nvidia-container-cli` userspace tooling for experimental gVisor
 GPU sandboxes; NVIDIA kernel drivers remain host-provided.
 It installs the checksum-pinned openYuanRong core wheel as the control plane
@@ -109,6 +111,7 @@ deployment entrypoint and environment.
 ```bash
 make build
 make build RUNTIME_PROFILE=python
+make build AKERNEL_ENABLE_RUNC=true
 ```
 
 For a build that will be pushed and deployed, set `IMAGE_REPOSITORY` and
@@ -126,11 +129,13 @@ node components and produces the AKernel all-in-one image using the selected
 runtime image and its matching service configuration.
 
 Initialize submodules with `git submodule update --init --recursive` before
-building. The all-in-one image builds `sandboxd` and `sbox` from
+building. The all-in-one image builds `sandboxd`, `sbox`, and `runc-shim` from
 `src/sandboxd`, builds `sandbox-logger`, builds `distill_fs` from
 `src/distill-fs`, downloads the official gVisor `runsc` release pinned by
 `GVISOR_RELEASE`, and extracts the required amd64 artifacts from the
-checksum-pinned Kata release.
+checksum-pinned Kata release. `AKERNEL_ENABLE_RUNC=true` additionally downloads
+the checksum-pinned official runc release and copies both runc binaries into
+the final image.
 
 The submodule gitlinks are the single source of truth for the sandboxd and
 distill-fs revisions included in a clean release. `make build` always compiles
@@ -178,6 +183,17 @@ from the node container. A node without KVM remains ready and advertises only
 runsc; a Kata request fails scheduling with a no-resource error when no
 eligible node exists. Do not treat a configured runtime as an advertised
 runtime.
+
+Runc is excluded from default image builds and from the default advertised
+runtime set. Guided cloud profiles use `make config ENABLE_RUNC=true`; this
+records both the image build flag and Terraform runtime registration. For
+direct configuration, build an image with `AKERNEL_ENABLE_RUNC=true`, then use
+`AKERNEL_ENABLE_RUNC=true` for standalone,
+`node.config.sandboxd.enableRunc=true` for Helm, or `enable_runc=true` for
+Terraform. Runc uses the host kernel and therefore has a different isolation
+boundary from runsc. It does not support experimental GPU or explicit
+`storage_mb` requests. Its optional `enableKVM` extra configuration requires a
+usable `/dev/kvm` device.
 
 The bundled sandboxd configuration enables per-sandbox network ACLs. The
 default iptables backend requires `br_netfilter`, conntrack,

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ ACR_NAMESPACE ?=
 MONITOR_STORAGE_CLASS ?=
 INSTALL_MONITOR ?=
 INSTALL_DRAGONFLY ?=
+ENABLE_RUNC ?=
 GRAFANA_PUBLIC_ACCESS ?=
 GRAFANA_ADMIN_PASSWORD ?=
 IAM_SEED_HEX ?=
@@ -47,9 +48,11 @@ help:
 	@echo "  make config FORCE=1                Overwrite an existing config without prompting"
 	@echo "  make config NON_INTERACTIVE=1 ...  Generate config from Make variables"
 	@echo "  make config INSTALL_DRAGONFLY=true Enable optional P2P image distribution"
+	@echo "  make config ENABLE_RUNC=true       Build and register the optional runc runtime"
 	@echo "  make build IMAGE_TAG=<tag>          Build the all-in-one image"
 	@echo "  make build RUNTIME_PROFILE=python   Include optional Python runtimes"
 	@echo "  make build AKERNEL_ENABLE_KATA=false Exclude the optional Kata payload"
+	@echo "  make build AKERNEL_ENABLE_RUNC=true Include the optional runc payload"
 	@echo "  make build GVISOR_RELEASE=<tag>     Override the pinned official gVisor tag"
 	@echo "  make versions                       Show locally selected component versions"
 	@echo "  make push                          Push the configured all-in-one image"
@@ -87,6 +90,7 @@ config:
 	if [[ -n "$(IMAGE_TAG)" ]]; then args+=(--image-tag "$(IMAGE_TAG)"); fi; \
 	if [[ -n "$(INSTALL_MONITOR)" ]]; then args+=(--install-monitor "$(INSTALL_MONITOR)"); fi; \
 	if [[ -n "$(INSTALL_DRAGONFLY)" ]]; then args+=(--install-dragonfly "$(INSTALL_DRAGONFLY)"); fi; \
+	if [[ -n "$(ENABLE_RUNC)" ]]; then args+=(--enable-runc "$(ENABLE_RUNC)"); fi; \
 	if [[ -n "$(GRAFANA_PUBLIC_ACCESS)" ]]; then args+=(--grafana-public-access "$(GRAFANA_PUBLIC_ACCESS)"); fi; \
 	if [[ -n "$(GRAFANA_ADMIN_PASSWORD)" ]]; then args+=(--grafana-admin-password "$(GRAFANA_ADMIN_PASSWORD)"); fi; \
 	if [[ -n "$(IAM_SEED_HEX)" ]]; then args+=(--iam-seed-hex "$(IAM_SEED_HEX)"); fi; \

--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ See the complete [basic usage example](./sdk/python/examples/basic_usage.py), th
 
 **Node-Level Infrastructure**
 - **Sandbox runtimes**: gVisor by default, including experimental NVIDIA GPU
-  and writable-storage support, and Kata Containers on KVM-capable nodes
+  and writable-storage support; Kata Containers on KVM-capable nodes; and an
+  explicitly enabled native Linux runc backend
 - **sandboxd**: Sandbox lifecycle daemon with pluggable sandbox runtime integration
 - **distill-fs**: Rust-based FUSE filesystem for lazy rootfs access, chunk caching, and deduplication
 
@@ -201,6 +202,7 @@ See the complete [basic usage example](./sdk/python/examples/basic_usage.py), th
 ## Roadmap
 
 - [x] Kata Containers runtime on KVM-capable nodes
+- [x] Optional native Linux runc runtime
 - [x] Sandbox network ACL
 - [ ] Fork-based sandbox launch based on gVisor
 - [ ] Sandbox checkpoint and restore

--- a/builder/node.Dockerfile
+++ b/builder/node.Dockerfile
@@ -6,6 +6,7 @@ ARG AKERNEL_NODE_BASE_IMAGE=ubuntu:24.04
 ARG AKERNEL_RUNTIME_IMAGE=akernel-runtime:local
 ARG AKERNEL_RUNTIME_PROFILE=rrt
 ARG AKERNEL_ENABLE_KATA=true
+ARG AKERNEL_ENABLE_RUNC=false
 ARG SANDBOXD_BUILD_IMAGE=golang:1.25.5-bookworm
 ARG DISTILL_FS_BUILD_IMAGE=rust:1.85.0-bookworm
 ARG OPEN_YR_VERSION=0.9.7
@@ -16,6 +17,10 @@ ARG OPEN_YR_CORE_AMD64_SHA256=0a890db1785e349bfd625844a05059bdd494e32a429cea771c
 ARG OPEN_YR_CORE_ARM64_SHA256=64e14233fcbbb3418311d2f242e164e7be6e7bee0315c7619b18d9c5ddd01a76
 ARG GVISOR_RELEASE=release-20260706.0
 ARG GVISOR_RELEASE_BASE_URL=https://storage.googleapis.com/gvisor/releases
+ARG RUNC_VERSION=1.5.1
+ARG RUNC_AMD64_SHA256=177df879d50c913eb205e898d5c1c05a18f574053c0ce5524c471208eaf06f6f
+ARG RUNC_RELEASE_BASE_URL=https://github.com/opencontainers/runc/releases/download
+ARG RUNC_BUILD_IMAGE=ubuntu:24.04
 ARG LIBNVIDIA_CONTAINER_VERSION=1.19.1-1
 ARG KATA_BUILD_IMAGE=ubuntu:24.04
 ARG KATA_RELEASE=4.0.0
@@ -78,6 +83,30 @@ WORKDIR /src/sandboxd
 COPY ./src/sandboxd/ ./
 RUN make release
 
+FROM ${RUNC_BUILD_IMAGE} AS runc-runtime-true
+ARG RUNC_VERSION
+ARG RUNC_AMD64_SHA256
+ARG RUNC_RELEASE_BASE_URL
+ARG TARGETARCH
+RUN set -eux; \
+    test "${TARGETARCH:-amd64}" = "amd64"; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    rm -rf /var/lib/apt/lists/*; \
+    asset=/tmp/runc.amd64; \
+    curl -fSL --retry 10 --retry-delay 2 --retry-all-errors \
+      "${RUNC_RELEASE_BASE_URL}/v${RUNC_VERSION}/runc.amd64" \
+      -o "${asset}"; \
+    echo "${RUNC_AMD64_SHA256}  ${asset}" | sha256sum -c -; \
+    install -D -m 0755 "${asset}" /runc/usr/local/bin/runc; \
+    rm -f "${asset}"
+COPY --from=sandboxd-builder /src/sandboxd/output/runc-shim /runc/usr/local/bin/runc-shim
+
+FROM ${RUNC_BUILD_IMAGE} AS runc-runtime-false
+RUN mkdir -p /runc/usr/local/bin
+
+FROM runc-runtime-${AKERNEL_ENABLE_RUNC} AS runc-runtime
+
 FROM ${DISTILL_FS_BUILD_IMAGE} AS distill-fs-builder
 ENV DEBIAN_FRONTEND=noninteractive \
     CARGO_NET_GIT_FETCH_WITH_CLI=true
@@ -98,6 +127,7 @@ RUN cargo build --locked --release --bin distill_fs
 
 FROM ${AKERNEL_NODE_BASE_IMAGE}
 ARG AKERNEL_ENABLE_KATA
+ARG AKERNEL_ENABLE_RUNC
 ARG AKERNEL_RUNTIME_PROFILE
 ARG AKERNEL_VERSION
 ARG AKERNEL_REVISION
@@ -109,6 +139,7 @@ ARG OPEN_YR_CORE_AMD64_SHA256
 ARG OPEN_YR_CORE_ARM64_SHA256
 ARG GVISOR_RELEASE
 ARG GVISOR_RELEASE_BASE_URL
+ARG RUNC_VERSION
 ARG LIBNVIDIA_CONTAINER_VERSION
 ARG OTELCOL_CONTRIB_URL
 ARG TARGETARCH
@@ -249,6 +280,7 @@ COPY --from=sandboxd-builder /src/sandboxd/output/sbox /usr/local/bin/sbox
 COPY --from=sandboxd-builder /src/sandboxd/output/sandbox-logger /usr/local/bin/sandbox-logger
 COPY --from=distill-fs-builder /src/distill-fs/target/release/distill_fs /usr/local/bin/distill_fs
 COPY --from=kata-runtime /kata/opt/kata /opt/kata
+COPY --from=runc-runtime /runc/usr/local/bin/ /usr/local/bin/
 RUN if [ "${AKERNEL_ENABLE_KATA}" = "true" ]; then \
       ln -sf /opt/kata/runtime-rs/bin/containerd-shim-kata-v2 /usr/local/bin/containerd-shim-kata-v2; \
     fi
@@ -266,6 +298,12 @@ RUN chmod 0755 \
         /usr/local/bin/ensure-component-cert \
         /usr/local/bin/sandboxd-network-prepare
 RUN if [ "${AKERNEL_ENABLE_KATA}" = "true" ]; then chmod 0755 /usr/local/bin/containerd-shim-kata-v2; fi
+RUN if [ "${AKERNEL_ENABLE_RUNC}" = "true" ]; then \
+      chmod 0755 /usr/local/bin/runc /usr/local/bin/runc-shim; \
+    else \
+      test ! -e /usr/local/bin/runc; \
+      test ! -e /usr/local/bin/runc-shim; \
+    fi
 
 COPY ./builder/config/yr_services.yaml /tmp/yr_services_rrt.yaml
 COPY ./builder/config/yr_services_python.yaml /tmp/yr_services_python.yaml
@@ -305,6 +343,8 @@ RUN mkdir -p ${YR_INSTALLATION_DIR}/logs ${YR_INSTALLATION_DIR}/metrics ${YR_INS
 LABEL org.opencontainers.image.version="${AKERNEL_VERSION}" \
       org.opencontainers.image.revision="${AKERNEL_REVISION}" \
       org.akernel.runtime.profile="${AKERNEL_RUNTIME_PROFILE}" \
+      org.akernel.runc.version="${RUNC_VERSION}" \
+      org.akernel.runc.enabled="${AKERNEL_ENABLE_RUNC}" \
       org.akernel.kata.enabled="${AKERNEL_ENABLE_KATA}"
 
 ENV YR_LOG_PATH=${YR_INSTALLATION_DIR}/logs

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -27,6 +27,13 @@ make e2e
 
 Kata Containers is enabled in the default AKernel runtime configuration and adds one host requirement: `/dev/kvm` must be available to the node container. Nodes without a usable KVM device remain ready and advertise only runsc. If no node advertises Kata, `Sandbox(runtime="kata")` fails scheduling with a no-resource error.
 
+The native Linux runc backend is opt-in because it uses the host kernel. For a
+guided cloud profile, `make config ENABLE_RUNC=true` records both sides of the
+selection: `make build` includes the checksum-pinned runc payload, and
+Terraform registers the runtime with sandboxd. Direct Helm users must likewise
+build with `AKERNEL_ENABLE_RUNC=true` and set
+`node.config.sandboxd.enableRunc=true`.
+
 The iptables sandbox NAT backend remains the default. Terraform deployments
 can set `sandboxd_nat_backend = "bpfnat"` to use sandboxd's experimental
 embedded TC eBPF backend on nodes without iptables NAT or conntrack modules.

--- a/deploy/akernel/charts/core/templates/node/configmap.yaml
+++ b/deploy/akernel/charts/core/templates/node/configmap.yaml
@@ -13,7 +13,15 @@ data:
     CPUQuota={{ .Values.node.config.resourceControl.cpuQuota | default "800%" }}
 
   sandboxd_config.toml: |
-{{ .Values.node.config.sandboxd.config | indent 4 }}
+{{- $sandboxdConfig := .Values.node.config.sandboxd.config }}
+{{- $runcMarker := "# AKERNEL_RUNTIME_RUNC" }}
+{{- if .Values.node.config.sandboxd.enableRunc }}
+{{- if not (contains $runcMarker $sandboxdConfig) }}
+{{- fail "node.config.sandboxd.enableRunc requires the # AKERNEL_RUNTIME_RUNC marker in node.config.sandboxd.config" }}
+{{- end }}
+{{- $sandboxdConfig = replace $runcMarker "runc=\"/usr/local/bin/runc\"" $sandboxdConfig }}
+{{- end }}
+{{ $sandboxdConfig | indent 4 }}
 
   registry.json: |
 {{ .Values.node.config.registry | toPrettyJson | indent 4 }}

--- a/deploy/akernel/charts/core/values.yaml
+++ b/deploy/akernel/charts/core/values.yaml
@@ -451,6 +451,9 @@ node:
       cpuQuota: "800%"
 
     sandboxd:
+      # The node image must also be built with AKERNEL_ENABLE_RUNC=true.
+      # Sandboxd probes runc and runc-shim before advertising the runtime.
+      enableRunc: false
       config: |-
         rootDir="/home/akernel/sandboxd/root"
         storeDir="/home/akernel/sandboxd/store"
@@ -488,16 +491,23 @@ node:
 
         [plugin.runtime.basic_spec]
         runsc="/home/akernel/images/config.json"
+        runc=""
 
         [plugin.runtime.runtime_binary]
         runsc="/usr/local/bin/runsc"
         kata="/usr/local/bin/containerd-shim-kata-v2"
+        # AKERNEL_RUNTIME_RUNC
 
         [plugin.runtime.kata]
         config_path="/opt/kata/share/defaults/kata-containers/runtime-rs/configuration-dragonball.toml"
         kvm_device="/dev/kvm"
         dan_config_dir="/run/kata-containers/dans"
         logger_binary="/usr/local/bin/sandbox-logger"
+
+        [plugin.runtime.runc]
+        state_root="/run/sandboxd/runc"
+        shim_binary="/usr/local/bin/runc-shim"
+        kvm_device="/dev/kvm"
 
         # image-manager config. root holds image-manager runtime state
         # (daemons/, mount_records.db) and is wiped on pod change; input

--- a/deploy/scripts/build-image.sh
+++ b/deploy/scripts/build-image.sh
@@ -127,6 +127,11 @@ if [[ -n "${env_name}" && -f "$(state_dir "${env_name}")/config.env" ]]; then
   tag="${tag:-${IMAGE_TAG}}"
 fi
 
+case "${AKERNEL_ENABLE_RUNC:-false}" in
+  true|false) ;;
+  *) die "AKERNEL_ENABLE_RUNC must be true or false" ;;
+esac
+
 repository="${repository:-akernel-all-in-one}"
 tag="${tag:-$(git -C "${AKERNEL_REPO_ROOT}" rev-parse --short HEAD)-$(date +%Y%m%d%H%M%S)}"
 
@@ -173,6 +178,7 @@ node_build_args=(
   --build-arg "AKERNEL_RUNTIME_IMAGE=${runtime_image}"
   --build-arg "AKERNEL_RUNTIME_PROFILE=${runtime_profile}"
   --build-arg "AKERNEL_ENABLE_KATA=${AKERNEL_ENABLE_KATA:-true}"
+  --build-arg "AKERNEL_ENABLE_RUNC=${AKERNEL_ENABLE_RUNC:-false}"
   --build-arg "AKERNEL_VERSION=${akernel_version}"
   --build-arg "AKERNEL_REVISION=${akernel_revision}"
 )

--- a/deploy/scripts/configure.sh
+++ b/deploy/scripts/configure.sh
@@ -30,6 +30,7 @@ image_repository_override=""
 image_tag_override=""
 install_monitor_override=""
 install_dragonfly_override=""
+enable_runc_override=""
 grafana_public_access_override=""
 grafana_admin_password_override=""
 iam_seed_hex_override=""
@@ -114,6 +115,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --install-dragonfly)
       install_dragonfly_override="$2"
+      shift 2
+      ;;
+    --enable-runc)
+      enable_runc_override="$2"
       shift 2
       ;;
     --grafana-public-access)
@@ -215,6 +220,7 @@ esac
 set_or_prompt image_tag "All-in-one image tag" "${default_tag}" "${image_tag_override}"
 set_or_prompt install_monitor "Install monitor chart (true/false)" "true" "${install_monitor_override}"
 set_or_prompt install_dragonfly "Install Dragonfly and dedicated node pools (true/false)" "false" "${install_dragonfly_override}"
+set_or_prompt enable_runc "Enable the optional runc runtime (true/false)" "false" "${enable_runc_override}"
 set_or_prompt grafana_public_access "Expose Grafana LoadBalancer (true/false)" "true" "${grafana_public_access_override}"
 set_or_prompt grafana_admin_password \
   "Grafana admin password (empty to generate)" "" \
@@ -224,6 +230,7 @@ if [[ -z "${grafana_admin_password}" ]]; then
 fi
 install_monitor="$(normalize_bool "${install_monitor}")"
 install_dragonfly="$(normalize_bool "${install_dragonfly}")"
+enable_runc="$(normalize_bool "${enable_runc}")"
 grafana_public_access="$(normalize_bool "${grafana_public_access}")"
 
 dir="$(state_dir "${env_name}")"
@@ -339,6 +346,7 @@ grafana_public_access  = ${grafana_public_access}
 grafana_admin_password = "${grafana_admin_password}"
 
 install_dragonfly = ${install_dragonfly}
+enable_runc       = ${enable_runc}
 EOF
     ;;
   huaweicloud)
@@ -392,6 +400,7 @@ grafana_public_access  = ${grafana_public_access}
 grafana_admin_password = "${grafana_admin_password}"
 
 install_dragonfly = ${install_dragonfly}
+enable_runc       = ${enable_runc}
 EOF
     ;;
 esac
@@ -412,6 +421,7 @@ IMAGE_TAG=${image_tag}
 CORE_NAMESPACE=akernel
 MONITOR_NAMESPACE=akernel-monitor
 INSTALL_DRAGONFLY=${install_dragonfly}
+AKERNEL_ENABLE_RUNC=${enable_runc}
 EOF
 
 chmod 600 "${tfvars_file}" "${config_file}"

--- a/deploy/standalone/README.md
+++ b/deploy/standalone/README.md
@@ -14,6 +14,21 @@ also enables its local-output DNAT support.
 
 The default runtime is gVisor `runsc`. `Sandbox(runtime="kata")` additionally requires `/dev/kvm` and hardware or nested virtualization on the Docker host. Nodes without KVM remain usable with runsc and do not advertise Kata to the scheduler.
 
+Default image builds exclude the optional native Linux `runc` runtime, and
+standalone does not advertise it by default. Build an image containing the
+payload, then enable it when host-kernel container isolation is appropriate:
+
+```bash
+AKERNEL_ENABLE_RUNC=true make build \
+  IMAGE_REPOSITORY=akernel-runc IMAGE_TAG=local
+
+IMAGE=akernel-runc:local AKERNEL_ENABLE_RUNC=true ./start.sh
+```
+
+Clients then select it with `Sandbox(runtime="runc")`. A sandbox may request
+the configured KVM character device with
+`extra_config={"enableKVM": True}` when the host exposes `/dev/kvm`.
+
 Experimental NVIDIA GPU sandboxes use gVisor nvproxy. The host must provide a
 compatible NVIDIA driver and NVIDIA Container Toolkit. Enable GPU access to
 the node container with:

--- a/deploy/standalone/config/sandboxd_config.toml
+++ b/deploy/standalone/config/sandboxd_config.toml
@@ -41,16 +41,23 @@ overlay_tmpfs_size="10G"
 
 [plugin.runtime.basic_spec]
 runsc="/home/akernel/images/config.json"
+runc=""
 
 [plugin.runtime.runtime_binary]
 runsc="/usr/local/bin/runsc"
 kata="/usr/local/bin/containerd-shim-kata-v2"
+# AKERNEL_RUNTIME_RUNC
 
 [plugin.runtime.kata]
 config_path="/opt/kata/share/defaults/kata-containers/runtime-rs/configuration-dragonball.toml"
 kvm_device="/dev/kvm"
 dan_config_dir="/run/kata-containers/dans"
 logger_binary="/usr/local/bin/sandbox-logger"
+
+[plugin.runtime.runc]
+state_root="/run/sandboxd/runc"
+shim_binary="/usr/local/bin/runc-shim"
+kvm_device="/dev/kvm"
 
 # image-manager config. root holds image-manager runtime state and is wiped
 # on pod change; input configs live under /home/akernel/sandboxd/config/ so the

--- a/deploy/standalone/start.sh
+++ b/deploy/standalone/start.sh
@@ -22,6 +22,7 @@ IAM_SEED_FILE="${DATA_DIR}/iam-seed"
 TOKEN_FILE="${DATA_DIR}/token"
 SANDBOXD_CONFIG_FILE="${DATA_DIR}/sandboxd/config.toml"
 AKERNEL_NAT_BACKEND="${AKERNEL_NAT_BACKEND:-iptables}"
+AKERNEL_ENABLE_RUNC="${AKERNEL_ENABLE_RUNC:-false}"
 LITEBUS_DATA_KEY=""
 
 # Container runtime command (docker or pouch)
@@ -93,6 +94,15 @@ check_prerequisites() {
         log_error "python3 is required to generate standalone credentials"
         exit 1
     fi
+
+    case "${AKERNEL_ENABLE_RUNC}" in
+        true|false)
+            ;;
+        *)
+            log_error "AKERNEL_ENABLE_RUNC must be true or false"
+            exit 1
+            ;;
+    esac
 
     # Create data directory
     mkdir -p "${DATA_DIR}"
@@ -228,6 +238,10 @@ configure_gpu() {
 
 configure_network() {
     local config_tmp="${SANDBOXD_CONFIG_FILE}.tmp"
+    local sed_args=(
+        -E
+        -e "s/^[[:space:]]*nat_backend[[:space:]]*=.*/nat_backend=\"${AKERNEL_NAT_BACKEND}\"/"
+    )
 
     case "${AKERNEL_NAT_BACKEND}" in
         iptables|bpfnat)
@@ -243,10 +257,22 @@ configure_network() {
         log_error "Missing nat_backend in ${CONFIG_DIR}/sandboxd_config.toml"
         exit 1
     fi
-    sed -E \
-        "s/^[[:space:]]*nat_backend[[:space:]]*=.*/nat_backend=\"${AKERNEL_NAT_BACKEND}\"/" \
-        "${CONFIG_DIR}/sandboxd_config.toml" > "${config_tmp}"
+    if [[ "${AKERNEL_ENABLE_RUNC}" == "true" ]]; then
+        if ! grep -q '^[[:space:]]*# AKERNEL_RUNTIME_RUNC[[:space:]]*$' \
+            "${CONFIG_DIR}/sandboxd_config.toml"; then
+            log_error "AKERNEL_ENABLE_RUNC requires the # AKERNEL_RUNTIME_RUNC marker in sandboxd_config.toml"
+            exit 1
+        fi
+        sed_args+=(
+            -e 's|^[[:space:]]*# AKERNEL_RUNTIME_RUNC[[:space:]]*$|runc="/usr/local/bin/runc"|'
+        )
+    fi
+    sed "${sed_args[@]}" "${CONFIG_DIR}/sandboxd_config.toml" > "${config_tmp}"
     mv "${config_tmp}" "${SANDBOXD_CONFIG_FILE}"
+
+    if [[ "${AKERNEL_ENABLE_RUNC}" == "true" ]]; then
+        log_info "Enabling the optional runc sandbox runtime"
+    fi
 
     if [[ "${AKERNEL_NAT_BACKEND}" == "bpfnat" ]]; then
         log_warn "Using the experimental bpfnat network backend"

--- a/deploy/terraform/aliyun/main.tf
+++ b/deploy/terraform/aliyun/main.tf
@@ -220,6 +220,7 @@ locals {
     master_service_type               = (var.master_public_access_8888 && !var.traefik_enabled) ? var.master_service_type : "ClusterIP"
     traefik_enabled                   = var.traefik_enabled
     sandboxd_nat_backend              = var.sandboxd_nat_backend
+    enable_runc                       = var.enable_runc
     node_secret_create                = var.node_secret_create
     node_home_use_csi_ephemeral       = var.node_home_use_csi_ephemeral
     node_home_csi_storage_class       = local.effective_node_home_csi_sc

--- a/deploy/terraform/aliyun/terraform.tfvars.example
+++ b/deploy/terraform/aliyun/terraform.tfvars.example
@@ -170,6 +170,10 @@ prereq_kruise_chart_version = "1.8.3"
 # Node secret control.
 node_secret_create = true
 
+# Optional host-kernel runc runtime. The node image must be built with the
+# matching AKERNEL_ENABLE_RUNC=true profile setting.
+enable_runc = false
+
 # --- Monitor ---
 install_monitor        = true
 monitor_namespace      = "akernel-monitor"

--- a/deploy/terraform/aliyun/values-akernel.yaml.tmpl
+++ b/deploy/terraform/aliyun/values-akernel.yaml.tmpl
@@ -166,6 +166,7 @@ node:
       memoryLimit: "2G"
       cpuQuota: "100%"
     sandboxd:
+      enableRunc: ${enable_runc}
       config: |-
         rootDir="/home/akernel/sandboxd/root"
         storeDir="/home/akernel/sandboxd/store"
@@ -200,16 +201,23 @@ node:
 
         [plugin.runtime.basic_spec]
         runsc="/home/akernel/images/config.json"
+        runc=""
 
         [plugin.runtime.runtime_binary]
         runsc="/usr/local/bin/runsc"
         kata="/usr/local/bin/containerd-shim-kata-v2"
+        # AKERNEL_RUNTIME_RUNC
 
         [plugin.runtime.kata]
         config_path="/opt/kata/share/defaults/kata-containers/runtime-rs/configuration-dragonball.toml"
         kvm_device="/dev/kvm"
         dan_config_dir="/run/kata-containers/dans"
         logger_binary="/usr/local/bin/sandbox-logger"
+
+        [plugin.runtime.runc]
+        state_root="/run/sandboxd/runc"
+        shim_binary="/usr/local/bin/runc-shim"
+        kvm_device="/dev/kvm"
 
         # image-manager config. root holds image-manager runtime state
         # (daemons/, mount_records.db) and is wiped on pod change; input

--- a/deploy/terraform/aliyun/variables.tf
+++ b/deploy/terraform/aliyun/variables.tf
@@ -315,6 +315,12 @@ variable "sandboxd_nat_backend" {
   default     = "iptables"
 }
 
+variable "enable_runc" {
+  type        = bool
+  description = "Request the optional runc runtime; the selected node image must be built with AKERNEL_ENABLE_RUNC=true."
+  default     = false
+}
+
 variable "node_home_use_csi_ephemeral" {
   type        = bool
   description = "Mount /home/akernel from a per-node CSI ephemeral volume instead of hostPath /home/akernel."

--- a/deploy/terraform/huaweicloud/main.tf
+++ b/deploy/terraform/huaweicloud/main.tf
@@ -112,6 +112,7 @@ locals {
     master_service_annotations     = merge(local.huaweicloud_master_elb_annotations, var.master_service_annotations)
     master_service_loadbalancer_ip = var.master_public_access_8888 ? var.master_service_loadbalancer_ip : ""
     sandboxd_nat_backend           = var.sandboxd_nat_backend
+    enable_runc                    = var.enable_runc
     node_secret_create             = var.node_secret_create
     node_home_use_csi_ephemeral    = var.node_home_use_csi_ephemeral
     node_home_csi_storage_class    = var.node_home_csi_storage_class

--- a/deploy/terraform/huaweicloud/terraform.tfvars.example
+++ b/deploy/terraform/huaweicloud/terraform.tfvars.example
@@ -89,6 +89,10 @@ node_image_tag            = "<release-tag>"
 # automatically; direct Terraform users can use `openssl rand -hex 32`.
 # iam_litebus_data_key = "<64-character-hex-seed>"
 
+# Optional host-kernel runc runtime. The node image must be built with the
+# matching AKERNEL_ENABLE_RUNC=true profile setting.
+enable_runc = false
+
 # Enable the /internal-stats endpoint sidecar on Traefik.
 # traefik_internal_stats_enabled = true
 # traefik_internal_stats_image   = "my-registry.example.com/busybox:1.37.0-musl"

--- a/deploy/terraform/huaweicloud/values-akernel.yaml.tmpl
+++ b/deploy/terraform/huaweicloud/values-akernel.yaml.tmpl
@@ -124,6 +124,7 @@ node:
       memoryLimit: "2G"
       cpuQuota: "100%"
     sandboxd:
+      enableRunc: ${enable_runc}
       config: |-
         rootDir="/home/akernel/sandboxd/root"
         storeDir="/home/akernel/sandboxd/store"
@@ -158,16 +159,23 @@ node:
 
         [plugin.runtime.basic_spec]
         runsc="/home/akernel/images/config.json"
+        runc=""
 
         [plugin.runtime.runtime_binary]
         runsc="/usr/local/bin/runsc"
         kata="/usr/local/bin/containerd-shim-kata-v2"
+        # AKERNEL_RUNTIME_RUNC
 
         [plugin.runtime.kata]
         config_path="/opt/kata/share/defaults/kata-containers/runtime-rs/configuration-dragonball.toml"
         kvm_device="/dev/kvm"
         dan_config_dir="/run/kata-containers/dans"
         logger_binary="/usr/local/bin/sandbox-logger"
+
+        [plugin.runtime.runc]
+        state_root="/run/sandboxd/runc"
+        shim_binary="/usr/local/bin/runc-shim"
+        kvm_device="/dev/kvm"
 
         # image-manager config. root holds image-manager runtime state
         # (daemons/, mount_records.db) and is wiped on pod change; input

--- a/deploy/terraform/huaweicloud/variables.tf
+++ b/deploy/terraform/huaweicloud/variables.tf
@@ -369,6 +369,12 @@ variable "sandboxd_nat_backend" {
   default     = "iptables"
 }
 
+variable "enable_runc" {
+  type        = bool
+  description = "Request the optional runc runtime; the selected node image must be built with AKERNEL_ENABLE_RUNC=true."
+  default     = false
+}
+
 variable "node_home_use_csi_ephemeral" {
   type        = bool
   description = "Mount /home/akernel from a per-node CSI ephemeral volume instead of hostPath /home/akernel."

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -103,6 +103,7 @@ Sandbox(
     storage_mb: int | None = None,
     network_policy: NetworkPolicy | None = None,
     dockerfile: DockerfileLaunch | None = None,
+    extra_config: Mapping[str, object] | None = None,
 )
 ```
 
@@ -200,9 +201,10 @@ configuration, as described in the
 ## Sandbox runtimes
 
 AKernel uses the gVisor `runsc` runtime when `runtime` is omitted. Runtime
-identifiers are forwarded to the selected backend instead of being restricted
-by an SDK-owned registry. The bundled deployment advertises `runsc` and Kata
-Containers:
+identifiers and optional `extra_config` are forwarded to the selected backend
+instead of being restricted or interpreted by an SDK-owned registry. Values in
+`extra_config` must be JSON-compatible. The bundled deployment advertises
+`runsc` and Kata Containers by default:
 
 ```python
 default_sandbox = Sandbox()
@@ -214,6 +216,32 @@ Kata requires at least one cluster node whose sandboxd instance successfully
 initialized the Kata runtime with a usable `/dev/kvm` device. Nodes without
 KVM remain available for runsc workloads and do not advertise Kata. A runtime
 that is unavailable in the cluster fails scheduling or backend validation.
+
+The all-in-one image can optionally package a native Linux `runc` backend.
+Operators build it with `AKERNEL_ENABLE_RUNC=true` and enable it explicitly
+because it provides host-kernel container isolation, not the user-space kernel
+boundary of runsc. Guided cloud profiles use
+`make config ENABLE_RUNC=true`; standalone deployments use
+`AKERNEL_ENABLE_RUNC=true`, and direct Helm deployments use
+`node.config.sandboxd.enableRunc=true`. After it is advertised:
+
+```python
+with Sandbox(runtime="runc") as sandbox:
+    print(sandbox.commands.run("uname -s").stdout)
+
+with Sandbox(
+    runtime="runc",
+    extra_config={"enableKVM": True},
+) as sandbox_with_kvm:
+    print(sandbox_with_kvm.commands.run("test -c /dev/kvm").exit_code)
+```
+
+`enableKVM` is owned by the runc backend and requires a usable `/dev/kvm` on
+the selected node. Runc supports OCI/EROFS root filesystems, read-only mounts,
+networking, command execution, and the default writable overlay. Experimental
+GPU requests and explicit `storage_mb` quotas remain runsc-only. See the
+[sandbox runtime comparison](../../src/sandboxd/doc/runtime.md) for the
+runtime capability boundaries.
 
 See [`examples/sandbox_runtime.py`](./examples/sandbox_runtime.py) for a runnable example.
 

--- a/sdk/python/akernel_sdk/_backends/base.py
+++ b/sdk/python/akernel_sdk/_backends/base.py
@@ -76,6 +76,7 @@ class SandboxSpec:
     xpu: str | None
     storage_mb: int | None
     network_policy: NetworkPolicy | None
+    extra_config: Mapping[str, object]
 
 
 class CommandsDriver(Protocol):

--- a/sdk/python/akernel_sdk/_backends/openyuanrong_sandbox.py
+++ b/sdk/python/akernel_sdk/_backends/openyuanrong_sandbox.py
@@ -373,6 +373,7 @@ class OpenYuanRongSandboxBackend:
                 xpu=spec.xpu,
                 storage_mb=spec.storage_mb,
                 network=network,
+                extra_config=dict(spec.extra_config),
                 create_timeout=create_timeout,
             )
         except Exception as error:

--- a/sdk/python/akernel_sdk/_backends/openyuanrong_sdk.py
+++ b/sdk/python/akernel_sdk/_backends/openyuanrong_sdk.py
@@ -291,6 +291,7 @@ class OpenYuanRongSdkBackend:
             xpu=spec.xpu,
             storage_mb=spec.storage_mb,
             network_policy=spec.network_policy,
+            extra_config=spec.extra_config,
         )
         try:
             instance = _impl.create_instance(

--- a/sdk/python/akernel_sdk/_backends/openyuanrong_sdk_impl.py
+++ b/sdk/python/akernel_sdk/_backends/openyuanrong_sdk_impl.py
@@ -156,6 +156,7 @@ def build_options(
     xpu: str | None,
     storage_mb: int | None,
     network_policy: NetworkPolicy | None,
+    extra_config: Mapping[str, object],
 ) -> Any:
     """Translate the stable SDK configuration to openYuanrong options."""
 
@@ -206,6 +207,8 @@ def build_options(
         options.custom_extensions["network_policy"] = json.dumps(
             network_policy.to_dict()
         )
+    if extra_config:
+        options.custom_extensions["extra_config"] = json.dumps(dict(extra_config))
 
     forwarded = list(port_forwardings)
     if reverse_tunnel is not None:

--- a/sdk/python/akernel_sdk/sandbox.py
+++ b/sdk/python/akernel_sdk/sandbox.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import ssl
 import urllib.request
 from collections.abc import Mapping, Sequence
@@ -66,6 +67,60 @@ def _normalize_mounts(mounts: Sequence[Mount] | None) -> list[Mount]:
     if not all(isinstance(mount, Mount) for mount in result):
         raise TypeError("mounts must contain only Mount objects")
     return result
+
+
+def _normalize_extra_config(
+    extra_config: Mapping[str, object] | None,
+) -> Mapping[str, object]:
+    """Validate and defensively copy runtime-owned JSON configuration."""
+
+    if extra_config is None:
+        return MappingProxyType({})
+    if not isinstance(extra_config, Mapping):
+        raise TypeError("extra_config must be a mapping")
+
+    active_containers: set[int] = set()
+
+    def normalize(value: object, path: str) -> object:
+        if value is None or isinstance(value, (bool, int, str)):
+            return value
+        if isinstance(value, float):
+            if not math.isfinite(value):
+                raise ValueError(f"{path} must contain only finite numbers")
+            return value
+        if isinstance(value, Mapping):
+            marker = id(value)
+            if marker in active_containers:
+                raise ValueError("extra_config must not contain circular references")
+            active_containers.add(marker)
+            try:
+                result: dict[str, object] = {}
+                for key, item in value.items():
+                    if not isinstance(key, str):
+                        raise TypeError(f"{path} keys must be strings")
+                    result[key] = normalize(item, f"{path}.{key}")
+                return result
+            finally:
+                active_containers.remove(marker)
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            marker = id(value)
+            if marker in active_containers:
+                raise ValueError("extra_config must not contain circular references")
+            active_containers.add(marker)
+            try:
+                return [
+                    normalize(item, f"{path}[{index}]")
+                    for index, item in enumerate(value)
+                ]
+            finally:
+                active_containers.remove(marker)
+        raise TypeError(f"{path} contains a non-JSON-compatible value")
+
+    normalized = normalize(extra_config, "extra_config")
+    assert isinstance(normalized, dict)
+    return MappingProxyType(normalized)
 
 
 def _validate_integer(
@@ -135,6 +190,7 @@ class Sandbox:
         storage_mb: int | None = None,
         network_policy: NetworkPolicy | None = None,
         dockerfile: DockerfileLaunch | None = None,
+        extra_config: Mapping[str, object] | None = None,
     ) -> None:
         """Create and wait for a sandbox to become ready.
 
@@ -177,6 +233,9 @@ class Sandbox:
                 explicitly declared in this Dockerfile, then executes build-time
                 instructions in-sandbox. Mutually exclusive with ``image`` and
                 ``rootfs``.
+            extra_config: Optional JSON-compatible configuration owned by the
+                selected runtime. AKernel validates and forwards it without
+                interpreting runtime-specific fields.
 
         Raises:
             TypeError: An argument has an invalid type.
@@ -244,6 +303,7 @@ class Sandbox:
 
         ports = _normalize_ports(port_forwardings)
         mount_list = _normalize_mounts(mounts)
+        normalized_extra_config = _normalize_extra_config(extra_config)
         if reverse_tunnel is not None:
             conflicts = set(ports).intersection(
                 {reverse_tunnel.reverse_port, reverse_tunnel.listen_port}
@@ -302,6 +362,7 @@ class Sandbox:
                 if network_policy is None or network_policy.is_empty
                 else network_policy
             ),
+            extra_config=normalized_extra_config,
         )
         self._session = load_backend().create(spec)
         try:

--- a/sdk/python/examples/sandbox_runtime.py
+++ b/sdk/python/examples/sandbox_runtime.py
@@ -16,7 +16,10 @@
 
 The Kata case requires at least one cluster node that advertises Kata support.
 Otherwise, the scheduler returns a no-resource error.
+Set AKERNEL_EXAMPLE_RUNC=true to include the optional runc runtime.
 """
+
+import os
 
 from akernel_sdk import Sandbox
 
@@ -25,7 +28,11 @@ def run(runtime: str | None) -> None:
     sandbox = (
         Sandbox(cpu=1000, memory=2048)
         if runtime is None
-        else Sandbox(runtime=runtime, cpu=1000, memory=2048)
+        else Sandbox(
+            runtime=runtime,
+            cpu=1000,
+            memory=2048,
+        )
     )
     with sandbox:
         result = sandbox.commands.run("uname -s")
@@ -37,6 +44,8 @@ def main() -> None:
     run(None)
     run("runsc")
     run("kata")
+    if os.environ.get("AKERNEL_EXAMPLE_RUNC", "").lower() == "true":
+        run("runc")
 
 
 if __name__ == "__main__":

--- a/sdk/python/tests/unit/test_backends.py
+++ b/sdk/python/tests/unit/test_backends.py
@@ -63,6 +63,7 @@ def _spec(**overrides):
         "xpu": None,
         "storage_mb": None,
         "network_policy": None,
+        "extra_config": MappingProxyType({}),
     }
     values.update(overrides)
     return SandboxSpec(**values)
@@ -175,6 +176,26 @@ class OpenYuanRongSandboxBackendTest(unittest.TestCase):
 
         self.assertEqual(sandbox_type.call_args.kwargs["runtime"], "runsc")
         self.assertIsNone(sandbox_type.call_args.kwargs["rootfs"])
+
+    def test_extra_config_is_forwarded_to_native_sdk(self):
+        native = MagicMock()
+        native.id = "default-custom-runtime"
+        with patch.object(
+            openyuanrong_sandbox.yr_sandbox,
+            "Sandbox",
+            return_value=native,
+        ) as sandbox_type:
+            self.backend.create(
+                _spec(
+                    runtime="custom-runtime",
+                    extra_config=MappingProxyType({"featureFlag": True}),
+                )
+            )
+
+        self.assertEqual(
+            sandbox_type.call_args.kwargs["extra_config"],
+            {"featureFlag": True},
+        )
 
     def test_explicit_kata_image_is_forwarded_to_native_sdk(self):
         native = MagicMock()

--- a/sdk/python/tests/unit/test_openyuanrong_sdk_impl.py
+++ b/sdk/python/tests/unit/test_openyuanrong_sdk_impl.py
@@ -42,6 +42,7 @@ class OpenYuanRongSdkImplTest(unittest.TestCase):
             "xpu": None,
             "storage_mb": None,
             "network_policy": None,
+            "extra_config": {},
         }
         values.update(overrides)
         return _impl.build_options(**values)
@@ -136,6 +137,17 @@ class OpenYuanRongSdkImplTest(unittest.TestCase):
         self.assertEqual(
             json.loads(options.custom_extensions["network_policy"]),
             {"dnsBlacklist": ["github.com", "*.github.com"]},
+        )
+
+    def test_extra_config_uses_custom_extension_wire_format(self):
+        options = self.build_options(
+            runtime="custom-runtime",
+            extra_config={"featureFlag": True, "labels": ["one", "two"]},
+        )
+
+        self.assertEqual(
+            json.loads(options.custom_extensions["extra_config"]),
+            {"featureFlag": True, "labels": ["one", "two"]},
         )
 
     def test_node_info_conversion(self):

--- a/sdk/python/tests/unit/test_sandbox.py
+++ b/sdk/python/tests/unit/test_sandbox.py
@@ -73,9 +73,41 @@ class SandboxTest(unittest.TestCase):
         self.assertIsNone(spec.xpu)
         self.assertIsNone(spec.storage_mb)
         self.assertIsNone(spec.network_policy)
+        self.assertEqual(dict(spec.extra_config), {})
         sandbox.kill()
         self.session.terminate.assert_called_once_with()
         self.session.close.assert_called_once_with()
+
+    def test_extra_config_is_validated_and_defensively_copied(self):
+        labels = ["worker"]
+        requested = {"featureFlag": True, "nested": {"labels": labels}}
+
+        sandbox = Sandbox(extra_config=requested)
+        spec = self.backend.create.call_args.args[0]
+        requested["featureFlag"] = False
+        labels.append("mutated")
+
+        self.assertEqual(
+            dict(spec.extra_config),
+            {"featureFlag": True, "nested": {"labels": ["worker"]}},
+        )
+        sandbox.kill()
+
+    def test_extra_config_rejects_non_json_values(self):
+        invalid = (
+            (["not", "a", "mapping"], TypeError),
+            ({1: "non-string key"}, TypeError),
+            ({"value": object()}, TypeError),
+            ({"value": float("inf")}, ValueError),
+        )
+        circular: dict[str, object] = {}
+        circular["self"] = circular
+        invalid += ((circular, ValueError),)
+
+        for value, error_type in invalid:
+            with self.subTest(value=value), self.assertRaises(error_type):
+                Sandbox(extra_config=value)
+        self.backend.create.assert_not_called()
 
     def test_kill_is_idempotent(self):
         sandbox = Sandbox()


### PR DESCRIPTION
## Summary

This PR adds optional runc support to the AKernel all-in-one image and exposes a generic `Sandbox(extra_config=...)` extension for runtime-owned configuration.

Runc remains disabled and unadvertised by default. When enabled, its checksum-pinned binaries are included in the image and the setting is propagated through standalone, Helm, and supported Terraform deployments. The sandboxd submodule is updated to the merged runc backend revision.

`extra_config` accepts JSON-compatible values and is forwarded without interpretation through both `openyuanrong-sandbox` and `openyuanrong-sdk`. It is runtime-agnostic and does not expose fields such as `enableKVM` as dedicated SDK parameters.

## Validation

- Completed runc standalone e2e validation.
- Completed lifecycle pressure and resource-leak checks.
- Verified both SDK backend forwarding paths with unit coverage.
- Verified the rebased changes with `git diff --check`.