### PR TITLE
build(integration): consume YuanRong 237 OBS wheels

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/sandboxd"]
 	path = src/sandboxd
-	url = https://github.com/inclusionAI/sandboxd.git
+	url = https://github.com/Chamberlain1998/sandboxd.git
 [submodule "src/distill-fs"]
 	path = src/distill-fs
 	url = https://github.com/inclusionAI/distill-fs.git

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ IMAGE_TAG ?=
 IMAGE_REPOSITORY ?=
 GVISOR_RELEASE ?=
 GVISOR_RELEASE_BASE_URL ?=
-OPEN_YR_CORE_WHEEL_URL ?=
-OPEN_YR_CORE_WHEEL_SHA256 ?=
+OPEN_YR_CORE_WHEEL_URL ?= https://openyuanrong.obs.cn-southwest-2.myhuaweicloud.com/daily/20260822051203/linux/amd64/openyuanrong_core-0.7.0%2B87cba622b491-py3-none-manylinux_2_31_x86_64.whl
+OPEN_YR_CORE_WHEEL_SHA256 ?= 9eb44e1ea59153ab9a65a81fc32450c09376e835732290046d028cec2db3b200
+OPEN_YR_RRT_WHEEL_URL ?= https://openyuanrong.obs.cn-southwest-2.myhuaweicloud.com/daily/20260822042459/linux/amd64/openyuanrong_rrt-0.7.0%2B87cba622b491-py3-none-manylinux_2_31_x86_64.whl
+OPEN_YR_RRT_WHEEL_SHA256 ?= 3aff1b4a676ca28992a2478adab900bc7bd1e76928cc12016ae50fea412a68c4
 TOKEN_TTL ?= $(if $(TTL),$(TTL),24h)
 TENANT ?= default
 ROLE ?= developer
@@ -106,6 +108,8 @@ build:
 	if [[ -n "$(GVISOR_RELEASE_BASE_URL)" ]]; then args+=(--gvisor-release-base-url "$(GVISOR_RELEASE_BASE_URL)"); fi; \
 	if [[ -n "$(OPEN_YR_CORE_WHEEL_URL)" ]]; then args+=(--open-yr-core-wheel-url "$(OPEN_YR_CORE_WHEEL_URL)"); fi; \
 	if [[ -n "$(OPEN_YR_CORE_WHEEL_SHA256)" ]]; then args+=(--open-yr-core-wheel-sha256 "$(OPEN_YR_CORE_WHEEL_SHA256)"); fi; \
+	if [[ -n "$(OPEN_YR_RRT_WHEEL_URL)" ]]; then args+=(--open-yr-rrt-wheel-url "$(OPEN_YR_RRT_WHEEL_URL)"); fi; \
+	if [[ -n "$(OPEN_YR_RRT_WHEEL_SHA256)" ]]; then args+=(--open-yr-rrt-wheel-sha256 "$(OPEN_YR_RRT_WHEEL_SHA256)"); fi; \
 	./deploy/scripts/build-image.sh "$${args[@]}"
 
 .PHONY: versions

--- a/builder/downloaders/download-openyuanrong-core.sh
+++ b/builder/downloaders/download-openyuanrong-core.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -ne 1 ]]; then
+  echo "usage: $0 DEST_DIR" >&2
+  exit 2
+fi
+
+destination_dir="$1"
+override_url="${OPEN_YR_CORE_WHEEL_URL:-}"
+override_sha256="${OPEN_YR_CORE_WHEEL_SHA256:-}"
+
+if [[ -n "${override_url}" && -z "${override_sha256}" ]] || \
+   [[ -z "${override_url}" && -n "${override_sha256}" ]]; then
+  echo "OPEN_YR_CORE_WHEEL_URL and OPEN_YR_CORE_WHEEL_SHA256 must be set together" >&2
+  exit 1
+fi
+
+if [[ -n "${override_url}" ]]; then
+  wheel_url="${override_url}"
+  wheel_sha256="${override_sha256}"
+  wheel_name="$(python3 -c '
+import os
+import sys
+import urllib.parse
+
+print(os.path.basename(urllib.parse.unquote(urllib.parse.urlparse(sys.argv[1]).path)))
+' "${wheel_url}")"
+else
+  case "${TARGETARCH:-}" in
+    amd64)
+      wheel_arch=x86_64
+      wheel_sha256="${OPEN_YR_CORE_AMD64_SHA256:?OPEN_YR_CORE_AMD64_SHA256 is required}"
+      ;;
+    arm64)
+      wheel_arch=aarch64
+      wheel_sha256="${OPEN_YR_CORE_ARM64_SHA256:?OPEN_YR_CORE_ARM64_SHA256 is required}"
+      ;;
+    "")
+      case "$(uname -m)" in
+        x86_64)
+          wheel_arch=x86_64
+          wheel_sha256="${OPEN_YR_CORE_AMD64_SHA256:?OPEN_YR_CORE_AMD64_SHA256 is required}"
+          ;;
+        aarch64|arm64)
+          wheel_arch=aarch64
+          wheel_sha256="${OPEN_YR_CORE_ARM64_SHA256:?OPEN_YR_CORE_ARM64_SHA256 is required}"
+          ;;
+        *)
+          echo "unsupported openYuanRong target architecture: $(uname -m)" >&2
+          exit 1
+          ;;
+      esac
+      ;;
+    *)
+      echo "unsupported openYuanRong target architecture: ${TARGETARCH}" >&2
+      exit 1
+      ;;
+  esac
+
+  open_yr_version="${OPEN_YR_VERSION:?OPEN_YR_VERSION is required}"
+  release_base_url="${OPEN_YR_RELEASE_BASE_URL:?OPEN_YR_RELEASE_BASE_URL is required}"
+  wheel_name="openyuanrong_core-${open_yr_version}-py3-none-manylinux_2_31_${wheel_arch}.whl"
+  wheel_url="${release_base_url}/${open_yr_version}/${wheel_name}"
+fi
+
+case "${wheel_name}" in
+  ?*.whl) ;;
+  *)
+    echo "openYuanRong core URL must reference a .whl file: ${wheel_url}" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "${destination_dir}"
+destination="${destination_dir}/${wheel_name}"
+[[ ! -e "${destination}" ]] || {
+  echo "openYuanRong core destination already exists: ${destination}" >&2
+  exit 1
+}
+
+temporary_dir="$(mktemp -d)"
+trap 'rm -rf "${temporary_dir}"' EXIT
+temporary_wheel="${temporary_dir}/${wheel_name}"
+
+curl -fSL --retry 10 --retry-delay 2 --retry-all-errors \
+  "${wheel_url}" -o "${temporary_wheel}"
+echo "${wheel_sha256}  ${temporary_wheel}" | sha256sum -c -
+mv "${temporary_wheel}" "${destination}"

--- a/builder/downloaders/download-openyuanrong-rrt.sh
+++ b/builder/downloaders/download-openyuanrong-rrt.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -ne 1 ]]; then
+  echo "usage: $0 DEST_FILE" >&2
+  exit 2
+fi
+
+destination="$1"
+override_url="${OPEN_YR_RRT_WHEEL_URL:-}"
+override_sha256="${OPEN_YR_RRT_WHEEL_SHA256:-}"
+
+if [[ -n "${override_url}" && -z "${override_sha256}" ]] || \
+   [[ -z "${override_url}" && -n "${override_sha256}" ]]; then
+  echo "OPEN_YR_RRT_WHEEL_URL and OPEN_YR_RRT_WHEEL_SHA256 must be set together" >&2
+  exit 1
+fi
+
+destination_dir="$(dirname "${destination}")"
+mkdir -p "${destination_dir}"
+[[ ! -d "${destination}" ]] || {
+  echo "RRT destination must be a file path: ${destination}" >&2
+  exit 1
+}
+
+temporary_dir="$(mktemp -d "${destination_dir}/.openyuanrong-rrt.XXXXXX")"
+trap 'rm -rf "${temporary_dir}"' EXIT
+candidate="${temporary_dir}/rrt-runtime"
+
+if [[ -n "${override_url}" ]]; then
+  wheel="${temporary_dir}/openyuanrong-rrt.whl"
+  curl -fSL --retry 10 --retry-delay 2 --retry-all-errors \
+    "${override_url}" -o "${wheel}"
+  echo "${override_sha256}  ${wheel}" | sha256sum -c -
+  unzip -p "${wheel}" openyuanrong_rrt/rrt-runtime >"${candidate}"
+else
+  runtime_url="${RRT_RUNTIME_URL:?RRT_RUNTIME_URL is required}"
+  runtime_sha256="${RRT_RUNTIME_SHA256:?RRT_RUNTIME_SHA256 is required}"
+  curl -fSL --retry 5 --retry-delay 2 --retry-all-errors \
+    "${runtime_url}" -o "${candidate}"
+  echo "${runtime_sha256}  ${candidate}" | sha256sum -c -
+fi
+
+[[ -s "${candidate}" ]] || {
+  echo "downloaded RRT runtime is empty" >&2
+  exit 1
+}
+mv "${candidate}" "${destination}"

--- a/builder/downloaders/tests/test-openyuanrong-downloaders.sh
+++ b/builder/downloaders/tests/test-openyuanrong-downloaders.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+CORE_DOWNLOADER="${ROOT}/builder/downloaders/download-openyuanrong-core.sh"
+RRT_DOWNLOADER="${ROOT}/builder/downloaders/download-openyuanrong-rrt.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+sha256() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+core_name="openyuanrong_core-0.7.0+build237-py3-none-manylinux_2_31_x86_64.whl"
+core_source="${TMP}/${core_name}"
+printf 'buildkite-237 core wheel\n' >"${core_source}"
+core_url="file://${core_source}"
+core_url="${core_url/+/%2B}"
+core_output="${TMP}/core-output"
+
+OPEN_YR_CORE_WHEEL_URL="${core_url}" \
+OPEN_YR_CORE_WHEEL_SHA256="$(sha256 "${core_source}")" \
+  "${CORE_DOWNLOADER}" "${core_output}"
+cmp "${core_source}" "${core_output}/${core_name}"
+
+bad_core_output="${TMP}/bad-core-output"
+mkdir -p "${bad_core_output}"
+if OPEN_YR_CORE_WHEEL_URL="${core_url}" \
+  OPEN_YR_CORE_WHEEL_SHA256=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff \
+    "${CORE_DOWNLOADER}" "${bad_core_output}" >/dev/null 2>&1; then
+  echo "core downloader accepted an invalid checksum" >&2
+  exit 1
+fi
+if find "${bad_core_output}" -mindepth 1 -print -quit | grep -q .; then
+  echo "core downloader published a failed download" >&2
+  exit 1
+fi
+
+rrt_root="${TMP}/rrt-wheel"
+rrt_wheel="${TMP}/openyuanrong_rrt-0.7.0+build237-py3-none-manylinux_2_31_x86_64.whl"
+mkdir -p "${rrt_root}/openyuanrong_rrt"
+printf 'buildkite-237 rrt runtime\n' >"${rrt_root}/openyuanrong_rrt/rrt-runtime"
+(
+  cd "${rrt_root}"
+  python3 -m zipfile -c "${rrt_wheel}" openyuanrong_rrt
+)
+rrt_output="${TMP}/rrt-runtime"
+
+OPEN_YR_RRT_WHEEL_URL="file://${rrt_wheel}" \
+OPEN_YR_RRT_WHEEL_SHA256="$(sha256 "${rrt_wheel}")" \
+  "${RRT_DOWNLOADER}" "${rrt_output}"
+cmp "${rrt_root}/openyuanrong_rrt/rrt-runtime" "${rrt_output}"
+
+if OPEN_YR_RRT_WHEEL_URL="file://${rrt_wheel}" \
+  OPEN_YR_RRT_WHEEL_SHA256='' \
+    "${RRT_DOWNLOADER}" "${TMP}/unpaired-rrt" >/dev/null 2>&1; then
+  echo "RRT downloader accepted a URL without a checksum" >&2
+  exit 1
+fi
+
+echo "openYuanRong downloader behavior checks passed"

--- a/builder/node.Dockerfile
+++ b/builder/node.Dockerfile
@@ -232,35 +232,17 @@ ENV YR_INSTALLATION_DIR=/home/yuanrong
 # Install the complete, language-runtime-free openYuanRong control plane from
 # its checksum-pinned core wheel. A URL and checksum pair may override the
 # release asset when validating an unreleased daily build.
+COPY ./builder/downloaders/download-openyuanrong-core.sh /usr/local/bin/
 RUN set -eux; \
-    case "${TARGETARCH:-}" in \
-      amd64) wheel_arch=x86_64; release_sha="${OPEN_YR_CORE_AMD64_SHA256}" ;; \
-      arm64) wheel_arch=aarch64; release_sha="${OPEN_YR_CORE_ARM64_SHA256}" ;; \
-      "") \
-        case "$(uname -m)" in \
-          x86_64) wheel_arch=x86_64; release_sha="${OPEN_YR_CORE_AMD64_SHA256}" ;; \
-          aarch64) wheel_arch=aarch64; release_sha="${OPEN_YR_CORE_ARM64_SHA256}" ;; \
-          *) echo "unsupported openYuanRong target architecture: $(uname -m)" >&2; exit 1 ;; \
-        esac ;; \
-      *) echo "unsupported openYuanRong target architecture: ${TARGETARCH}" >&2; exit 1 ;; \
-    esac; \
-    wheel_name="openyuanrong_core-${OPEN_YR_VERSION}-py3-none-manylinux_2_31_${wheel_arch}.whl"; \
-    wheel_url="${OPEN_YR_RELEASE_BASE_URL}/${OPEN_YR_VERSION}/${wheel_name}"; \
-    wheel_sha="${release_sha}"; \
-    if [ -n "${OPEN_YR_CORE_WHEEL_URL}" ]; then \
-      test -n "${OPEN_YR_CORE_WHEEL_SHA256}"; \
-      wheel_name="$(python3 -c 'import os, sys, urllib.parse; print(os.path.basename(urllib.parse.unquote(urllib.parse.urlparse(sys.argv[1]).path)))' "${OPEN_YR_CORE_WHEEL_URL}")"; \
-      case "${wheel_name}" in *.whl) ;; *) echo "OPEN_YR_CORE_WHEEL_URL must reference a .whl file" >&2; exit 1 ;; esac; \
-      wheel_url="${OPEN_YR_CORE_WHEEL_URL}"; \
-      wheel_sha="${OPEN_YR_CORE_WHEEL_SHA256}"; \
-    else \
-      test -z "${OPEN_YR_CORE_WHEEL_SHA256}"; \
-    fi; \
-    wheel="/tmp/${wheel_name}"; \
+    download_dir=/tmp/openyuanrong-core-download; \
+    mkdir -p "${download_dir}"; \
+    chmod 0755 /usr/local/bin/download-openyuanrong-core.sh; \
+    /usr/local/bin/download-openyuanrong-core.sh "${download_dir}"; \
+    set -- "${download_dir}"/*.whl; \
+    test "$#" -eq 1; \
+    wheel="$1"; \
+    test -f "${wheel}"; \
     target=/tmp/openyuanrong-core; \
-    curl -fSL --retry 10 --retry-delay 2 --retry-all-errors \
-      "${wheel_url}" -o "${wheel}"; \
-    echo "${wheel_sha}  ${wheel}" | sha256sum -c -; \
     python3 -m pip install \
       --break-system-packages \
       --no-cache-dir \
@@ -270,7 +252,8 @@ RUN set -eux; \
     test -x "${target}/yr/functionsystem/bin/yr"; \
     mkdir -p "${YR_INSTALLATION_DIR}"; \
     cp -a "${target}/yr/." "${YR_INSTALLATION_DIR}/"; \
-    rm -rf "${target}" "${wheel}"; \
+    rm -rf "${target}" "${download_dir}"; \
+    rm -f /usr/local/bin/download-openyuanrong-core.sh; \
     ln -sfn "${YR_INSTALLATION_DIR}/functionsystem/bin/yr" /usr/bin/yr
 
 COPY --from=runtime-image /yr-runtime-rootfs.img ${YR_INSTALLATION_DIR}/yr-runtime-rootfs.img

--- a/builder/runtime.Dockerfile
+++ b/builder/runtime.Dockerfile
@@ -10,22 +10,29 @@ ARG PYTHON_312_VERSION=3.12.11
 ARG PYTHON_313_VERSION=3.13.5
 ARG PYTHON_314_VERSION=3.14.6
 ARG OPEN_YR_VERSION=0.9.9
+ARG OPEN_YR_RRT_WHEEL_URL=
+ARG OPEN_YR_RRT_WHEEL_SHA256=
 
 FROM ${AKERNEL_RUNTIME_BASE_IMAGE} AS rrt-download
 
 ARG OPEN_YR_VERSION
 ARG RRT_RUNTIME_URL=https://github.com/openYuanrong-mirror/yuanrong/releases/download/${OPEN_YR_VERSION}/rrt-runtime-amd64
 ARG RRT_RUNTIME_SHA256=d2e5a43cd1d384e0c58174821fc787e7946fb330b23021769a823625a2401274
+ARG OPEN_YR_RRT_WHEEL_URL
+ARG OPEN_YR_RRT_WHEEL_SHA256
+ARG TARGETARCH
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates curl && \
+    apt-get install -y --no-install-recommends ca-certificates curl file unzip && \
     rm -rf /var/lib/apt/lists/*
 
+COPY ./builder/downloaders/download-openyuanrong-rrt.sh /usr/local/bin/
 RUN set -eux; \
-    curl -fSL --retry 5 --retry-delay 2 --retry-all-errors \
-        -o /rrt-runtime "${RRT_RUNTIME_URL}"; \
-    echo "${RRT_RUNTIME_SHA256}  /rrt-runtime" | sha256sum -c -; \
-    chmod 0755 /rrt-runtime
+    case "${TARGETARCH:-amd64}" in amd64) ;; *) echo "RRT runtime only supports amd64" >&2; exit 1 ;; esac; \
+    chmod 0755 /usr/local/bin/download-openyuanrong-rrt.sh; \
+    /usr/local/bin/download-openyuanrong-rrt.sh /rrt-runtime; \
+    chmod 0755 /rrt-runtime; \
+    file /rrt-runtime | grep -Eq 'ELF 64-bit LSB.*x86-64'
 
 FROM ${AKERNEL_RUNTIME_BASE_IMAGE} AS rrt-runtime-rootfs
 

--- a/deploy/scripts/build-image.sh
+++ b/deploy/scripts/build-image.sh
@@ -19,6 +19,8 @@ gvisor_release=""
 gvisor_release_base_url=""
 open_yr_core_wheel_url="${OPEN_YR_CORE_WHEEL_URL:-}"
 open_yr_core_wheel_sha256="${OPEN_YR_CORE_WHEEL_SHA256:-}"
+open_yr_rrt_wheel_url="${OPEN_YR_RRT_WHEEL_URL:-}"
+open_yr_rrt_wheel_sha256="${OPEN_YR_RRT_WHEEL_SHA256:-}"
 print_component_versions=0
 
 component_revision() {
@@ -99,6 +101,14 @@ while [[ $# -gt 0 ]]; do
       open_yr_core_wheel_sha256="$2"
       shift 2
       ;;
+    --open-yr-rrt-wheel-url)
+      open_yr_rrt_wheel_url="$2"
+      shift 2
+      ;;
+    --open-yr-rrt-wheel-sha256)
+      open_yr_rrt_wheel_sha256="$2"
+      shift 2
+      ;;
     --print-component-versions)
       print_component_versions=1
       shift
@@ -118,6 +128,11 @@ case "${AKERNEL_ENABLE_KATA:-true}" in
   true|false) ;;
   *) die "AKERNEL_ENABLE_KATA must be true or false" ;;
 esac
+if [[ -n "${open_yr_rrt_wheel_url}" || -n "${open_yr_rrt_wheel_sha256}" ]]; then
+  if [[ -z "${open_yr_rrt_wheel_url}" || -z "${open_yr_rrt_wheel_sha256}" ]]; then
+    die "OPEN_YR_RRT_WHEEL_URL and OPEN_YR_RRT_WHEEL_SHA256 must be set together"
+  fi
+fi
 
 require_cmd docker
 
@@ -167,11 +182,21 @@ if [[ "${print_component_versions}" == "1" ]]; then
 fi
 
 info "building ${runtime_image} with runtime profile ${runtime_profile}"
-docker build \
-  -f builder/runtime.Dockerfile \
-  --target "runtime-${runtime_profile}" \
-  -t "${runtime_image}" \
-  .
+build_runtime_image() {
+  docker build \
+    -f builder/runtime.Dockerfile \
+    "$@" \
+    --target "runtime-${runtime_profile}" \
+    -t "${runtime_image}" \
+    .
+}
+if [[ -n "${open_yr_rrt_wheel_url}" ]]; then
+  build_runtime_image \
+    --build-arg "OPEN_YR_RRT_WHEEL_URL=${open_yr_rrt_wheel_url}" \
+    --build-arg "OPEN_YR_RRT_WHEEL_SHA256=${open_yr_rrt_wheel_sha256}"
+else
+  build_runtime_image
+fi
 
 info "building ${all_in_one_image}"
 node_build_args=(

--- a/deploy/scripts/tests/test-build-image-yuanrong-obs.sh
+++ b/deploy/scripts/tests/test-build-image-yuanrong-obs.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+core_url='https://openyuanrong.obs.cn-southwest-2.myhuaweicloud.com/daily/20260822051203/linux/amd64/openyuanrong_core-0.7.0%2B87cba622b491-py3-none-manylinux_2_31_x86_64.whl'
+core_sha='9eb44e1ea59153ab9a65a81fc32450c09376e835732290046d028cec2db3b200'
+rrt_url='https://openyuanrong.obs.cn-southwest-2.myhuaweicloud.com/daily/20260822042459/linux/amd64/openyuanrong_rrt-0.7.0%2B87cba622b491-py3-none-manylinux_2_31_x86_64.whl'
+rrt_sha='3aff1b4a676ca28992a2478adab900bc7bd1e76928cc12016ae50fea412a68c4'
+
+mkdir -p "${TMP}/bin"
+cat >"${TMP}/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${DOCKER_LOG}"
+EOF
+chmod +x "${TMP}/bin/docker"
+
+DOCKER_LOG="${TMP}/docker.log" \
+PATH="${TMP}/bin:${PATH}" \
+  make -C "${ROOT}" SHELL=/bin/bash build \
+    ENV=obs-contract-test \
+    IMAGE_REPOSITORY=registry.example.invalid/akernel \
+    IMAGE_TAG=build-237
+
+runtime_invocation="$(sed -n '1p' "${TMP}/docker.log")"
+node_invocation="$(sed -n '2p' "${TMP}/docker.log")"
+
+for expected in \
+  "OPEN_YR_RRT_WHEEL_URL=${rrt_url}" \
+  "OPEN_YR_RRT_WHEEL_SHA256=${rrt_sha}"; do
+  [[ "${runtime_invocation}" == *"${expected}"* ]] || {
+    echo "runtime build is missing ${expected}" >&2
+    exit 1
+  }
+done
+
+for expected in \
+  "OPEN_YR_CORE_WHEEL_URL=${core_url}" \
+  "OPEN_YR_CORE_WHEEL_SHA256=${core_sha}"; do
+  [[ "${node_invocation}" == *"${expected}"* ]] || {
+    echo "node build is missing ${expected}" >&2
+    exit 1
+  }
+done
+
+invalid_log="${TMP}/invalid-docker.log"
+if DOCKER_LOG="${invalid_log}" PATH="${TMP}/bin:${PATH}" \
+  "${ROOT}/deploy/scripts/build-image.sh" \
+    --repository registry.example.invalid/akernel \
+    --tag invalid \
+    --open-yr-rrt-wheel-url "${rrt_url}" \
+    >"${TMP}/invalid.out" 2>&1; then
+  echo "build accepted an RRT URL without a checksum" >&2
+  exit 1
+fi
+grep -Fq \
+  'OPEN_YR_RRT_WHEEL_URL and OPEN_YR_RRT_WHEEL_SHA256 must be set together' \
+  "${TMP}/invalid.out"
+[[ ! -e "${invalid_log}" ]] || {
+  echo "invalid RRT override reached Docker" >&2
+  exit 1
+}
+
+echo "Buildkite 237 OBS build contract checks passed"


### PR DESCRIPTION
## Purpose

This is a minimal integration PR for YuanRong Buildkite #237 and the checkpoint-capable sandboxd branch. The branch is ready for joint image-build and pause/resume validation with `make build`.

## Pinned integration inputs

- YuanRong commit: `87cba622b491f7303415d179f3fa2fdae98e69e7` from Buildkite #237
- core OBS wheel SHA-256: `9eb44e1ea59153ab9a65a81fc32450c09376e835732290046d028cec2db3b200`
- RRT OBS wheel SHA-256: `3aff1b4a676ca28992a2478adab900bc7bd1e76928cc12016ae50fea412a68c4`
- sandboxd source: `Chamberlain1998/sandboxd:codex/native-gvisor-checkpoint-v1`
- sandboxd gitlink: `55971e14f533a79ac84d9e23ad455ca1e9d56c47`

## Scope

- Add checksum-verifying core and RRT wheel downloaders.
- Wire the downloaders into the existing node/runtime Dockerfiles.
- Pin the #237 non-release OBS URLs in this integration branch.
- Point the sandboxd submodule and gitlink at the checkpoint branch.
- Add focused downloader and build-argument tests.

This PR intentionally contains no AKernel Buildkite pipeline, PVC/cache, SDK, deployment, or unrelated documentation changes.

## Current status

- Downloader behavior checks pass.
- `make build` forwards both #237 OBS URL/SHA pairs to the correct Docker builds.
- The sandboxd URL, remote branch tip, worktree HEAD, and staged gitlink all resolve to `55971e14...`.
- A previous ECS image build validated the same YuanRong #237 artifacts and sandboxd revision; this rebased minimal branch has not been rebuilt end to end.

The OBS objects are daily-build artifacts rather than durable release assets and are intended only for this integration window.