### PR TITLE
feat(runtime): package and enable Firecracker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,11 @@ jobs:
 
       - name: Prepare host kernel modules
         run: |
+          sudo modprobe tun
           sudo modprobe loop
           sudo modprobe erofs
           sudo modprobe br_netfilter
+          test -c /dev/net/tun
           sudo sysctl -w net.bridge.bridge-nf-call-iptables=1
 
       - name: Build all-in-one image

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,15 +11,15 @@ developer workflows. The current public user-facing surface is the Python
 `akernel-sdk`, including the `akernel_sdk.Sandbox` API and the `ak` CLI.
 The default sandbox runtime is gVisor runsc. Runtime identifiers and generic
 JSON-compatible runtime configuration are forwarded to the selected backend,
-which owns availability and compatibility checks; the bundled deployment also
-advertises Kata Containers on KVM-capable nodes. The native Linux runc payload
-is build-time optional and must be explicitly included and enabled by an
-operator.
+which owns availability and compatibility checks. The bundled deployment also
+advertises Kata Containers and Firecracker on KVM-capable nodes. The native
+Linux runc payload is build-time optional and must be explicitly included and
+enabled by an operator.
 Creation-time network policies support unrestricted networking, blocking new
 flows except the YuanRong control and published sandbox-port routes, or denying
 exact and leading-wildcard DNS names.
-Experimental whole-device NVIDIA GPU and configurable writable-storage
-requests currently require runsc.
+Experimental whole-device NVIDIA GPU requests require runsc. Configurable
+writable-storage requests are supported by runsc and Firecracker.
 
 Use AKernel when a task needs an isolated remote environment with command
 execution, file operations, interactive PTYs, port forwarding, or reverse
@@ -47,20 +47,9 @@ tunnels. The project overview and deployment quick start are in
 
 The open-source AKernel repository contains the SDK, deployment configuration,
 build tooling, and examples. Node runtime components such as `sandboxd` and
-`distill-fs` are maintained in their own upstream repositories. The all-in-one
-Docker build copies and compiles their pinned Git submodules in dedicated
-builder stages. It downloads the gVisor `runsc` binary selected by
-`src/sandboxd/third_party/runtime-versions.env` and verifies its SHA-512
-digest. Keep the release tag, binary URL, and checksum synchronized in that
-shared manifest.
-When `AKERNEL_ENABLE_RUNC=true`, the build installs a pinned runc release
-after verifying its SHA-256 digest. The node image includes the pinned
-`nvidia-container-cli` userspace tooling for experimental gVisor GPU
-sandboxes; NVIDIA kernel drivers remain host-provided.
-It installs the checksum-pinned openYuanRong core wheel as the control plane
-and packages the checksum-pinned Kata Containers 4.0 runtime-rs shim,
-Dragonball configuration, guest kernel, guest images, license, and sandbox
-logger.
+`distill-fs` are maintained in their own upstream repositories and pinned as
+Git submodules. The all-in-one build compiles those revisions and packages the
+runtime payloads described in the Build section below.
 
 ## Common Commands
 
@@ -117,6 +106,7 @@ deployment entrypoint and environment.
 make build
 make build RUNTIME_PROFILE=python
 make build AKERNEL_ENABLE_RUNC=true
+make build AKERNEL_ENABLE_FIRECRACKER=false
 ```
 
 For a build that will be pushed and deployed, set `IMAGE_REPOSITORY` and
@@ -134,19 +124,18 @@ node components and produces the AKernel all-in-one image using the selected
 runtime image and its matching service configuration.
 
 Initialize submodules with `git submodule update --init --recursive` before
-building. The all-in-one image builds `sandboxd`, `sbox`, and `runc-shim` from
-`src/sandboxd`, builds `sandbox-logger`, builds `distill_fs` from
-`src/distill-fs`, installs the checksum-pinned gVisor `runsc`, and extracts
-the required amd64 artifacts from the checksum-pinned Kata release.
-`AKERNEL_ENABLE_RUNC=true` additionally downloads the checksum-pinned official
-runc release and copies both runc binaries into the final image.
+building. The all-in-one image builds the sandboxd binaries, including
+`firecracker-agent`, and `distill_fs`; installs checksum-pinned gVisor and Kata
+artifacts; installs the Firecracker VMM and guest kernel; and constructs the
+matching guest-agent initrd. Runc remains build-time optional, and
+`AKERNEL_ENABLE_FIRECRACKER=false` excludes the Firecracker payload.
 
 The sandboxd submodule's runtime manifest is the source of truth for the
-gVisor release used by both sandboxd E2E and AKernel packaging. Test an
-unreleased runtime by checking out the sandboxd commit that pins it rather
-than overriding manifest fields from the AKernel build. Keep sandboxd's
-pooled-TAP contract and the matching gVisor compatibility patches validated
-together when upgrading.
+gVisor and Firecracker releases used by both sandboxd E2E and AKernel
+packaging. Test an unreleased runtime by checking out the sandboxd commit that
+pins it rather than overriding manifest fields from the AKernel build. Keep
+sandboxd's pooled-TAP contract and the matching gVisor compatibility patches
+validated together when upgrading.
 
 The submodule gitlinks are the single source of truth for the sandboxd and
 distill-fs revisions included in a clean release. `make build` always compiles
@@ -188,12 +177,25 @@ make deploy
 make print-env
 ```
 
-Kata is present in the default AKernel runtime configuration but is an
-optional node capability. It additionally requires `/dev/kvm` to be usable
-from the node container. A node without KVM remains ready and advertises only
-runsc; a Kata request fails scheduling with a no-resource error when no
-eligible node exists. Do not treat a configured runtime as an advertised
-runtime.
+Kata and Firecracker are present in the default AKernel runtime configuration
+but are optional node capabilities. Both require `/dev/kvm` to be usable from
+the node container. Firecracker additionally validates its VMM, guest kernel,
+initrd, and `mkfs.ext4`. A node without KVM remains ready for runsc workloads
+and advertises neither VM runtime; a Kata or Firecracker request fails
+scheduling with a no-resource error when no eligible node exists. Do not treat
+a configured runtime as an advertised runtime.
+
+Firecracker supports commands, files, PTYs, network policies, published ports,
+reverse tunnels, read-only EROFS image roots and mounts, explicit `storage_mb`
+quotas, and recovery across sandboxd restarts. Its root and filesystem image
+mounts must be local or image-provider-backed regular EROFS files. It rejects
+OCI/Nydus directory roots, directory mounts, writable live host binds, NVIDIA
+GPUs, and nested KVM rather than weakening their semantics.
+
+Do not add Firecracker-specific directory conversion, image caching, or
+artifact reference counting to sandboxd or its image manager. Build EROFS
+before sandbox creation and distribute it through the existing local or S3
+imagefile paths. The bundled default runtime root already follows this model.
 
 Runc is excluded from default image builds and from the default advertised
 runtime set. Guided cloud profiles use `make config ENABLE_RUNC=true`; this
@@ -206,8 +208,9 @@ boundary from runsc. It does not support experimental GPU or explicit
 `storage_mb` requests. Its optional `enableKVM` extra configuration requires a
 usable `/dev/kvm` device.
 
-The bundled sandboxd configuration enables per-sandbox network ACLs. The
-default iptables backend requires `br_netfilter`, conntrack,
+The bundled sandboxd configuration enables per-sandbox network ACLs. Pooled TAP
+networking requires the host `tun` module and a usable `/dev/net/tun`. The
+default iptables backend additionally requires `br_netfilter`, conntrack,
 connmark/CONNMARK, and bridge netfilter. The optional bpfnat backend instead
 requires eBPF `SCHED_CLS`, TC `clsact`, writable bpffs, and permission to load
 BPF programs and manage TC filters. Both require free TCP/UDP port 53 on the
@@ -309,10 +312,10 @@ with Sandbox(
     print(sb.commands.run("test -c /dev/kvm").exit_code)
 ```
 
-Request experimental gVisor GPU and disk-backed writable storage resources:
+Request an experimental gVisor GPU:
 
 ```python
-with Sandbox(xpu="gpu:l20:1", storage_mb=20 * 1024) as sb:
+with Sandbox(xpu="gpu:l20:1") as sb:
     print(sb.commands.run("nvidia-smi -L").stdout)
 ```
 
@@ -360,9 +363,10 @@ default-route interface address in standalone mode; `AKERNEL_NODE_IP` is the
 explicit override for multi-homed environments.
 
 The standalone sandboxd filestore is a loop-mounted ext4 image under the
-bind-mounted `deploy/standalone/data/` directory. Explicit `storage_mb` quotas
-use this local-disk filestore; omitting `storage_mb` retains the configured
-memory-backed writable overlay.
+bind-mounted `deploy/standalone/data/` directory. Explicit `storage_mb`
+quotas for runsc and Firecracker use this local-disk filestore. Without an
+explicit quota, runsc retains its configured memory-backed overlay while
+Firecracker creates its configured sparse ext4 default.
 
 Keep detailed SDK reference material with the SDK. The root README should
 contain only the project-level entry points and representative examples:
@@ -443,17 +447,23 @@ Run the basic e2e example against a deployed cluster with:
 make e2e
 ```
 
-The SDK integration and pressure tests are runtime-selectable. Kata tests
-require a KVM-capable standalone or cluster node:
+The SDK integration and pressure tests are runtime-selectable. Kata and
+Firecracker tests require a KVM-capable standalone or cluster node:
 
 ```bash
 AKERNEL_RUN_INTEGRATION=1 \
 AKERNEL_TEST_RUNTIME=kata \
-python -m pytest sdk/python/tests/integration/test_sandbox.py
+python sdk/python/tests/integration/test_sandbox.py -v
 
 python sdk/python/benchmarks/sandbox_pressure.py --runtime kata
 
-python sdk/python/benchmarks/sandbox_pressure.py --storage-mb 256
+AKERNEL_RUN_INTEGRATION=1 \
+AKERNEL_TEST_RUNTIME=firecracker \
+python sdk/python/tests/integration/test_sandbox.py -v
+
+python sdk/python/benchmarks/sandbox_pressure.py --runtime firecracker
+python sdk/python/benchmarks/sandbox_pressure.py \
+  --runtime firecracker --storage-mb 256
 python sdk/python/benchmarks/sandbox_pressure.py \
   --xpu gpu:a10:1 --storage-mb 256 --processes 1 --threads 1
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,12 +49,14 @@ The open-source AKernel repository contains the SDK, deployment configuration,
 build tooling, and examples. Node runtime components such as `sandboxd` and
 `distill-fs` are maintained in their own upstream repositories. The all-in-one
 Docker build copies and compiles their pinned Git submodules in dedicated
-builder stages. It also downloads `runsc` from the official gVisor release
-bucket and verifies its published SHA-512 checksum. When
-`AKERNEL_ENABLE_RUNC=true`, it also installs a pinned runc release after
-verifying its SHA-256 digest. The node image includes
-the pinned `nvidia-container-cli` userspace tooling for experimental gVisor
-GPU sandboxes; NVIDIA kernel drivers remain host-provided.
+builder stages. It downloads the gVisor `runsc` binary selected by
+`src/sandboxd/third_party/runtime-versions.env` and verifies its SHA-512
+digest. Keep the release tag, binary URL, and checksum synchronized in that
+shared manifest.
+When `AKERNEL_ENABLE_RUNC=true`, the build installs a pinned runc release
+after verifying its SHA-256 digest. The node image includes the pinned
+`nvidia-container-cli` userspace tooling for experimental gVisor GPU
+sandboxes; NVIDIA kernel drivers remain host-provided.
 It installs the checksum-pinned openYuanRong core wheel as the control plane
 and packages the checksum-pinned Kata Containers 4.0 runtime-rs shim,
 Dragonball configuration, guest kernel, guest images, license, and sandbox
@@ -134,11 +136,17 @@ runtime image and its matching service configuration.
 Initialize submodules with `git submodule update --init --recursive` before
 building. The all-in-one image builds `sandboxd`, `sbox`, and `runc-shim` from
 `src/sandboxd`, builds `sandbox-logger`, builds `distill_fs` from
-`src/distill-fs`, downloads the official gVisor `runsc` release pinned by
-`GVISOR_RELEASE`, and extracts the required amd64 artifacts from the
-checksum-pinned Kata release. `AKERNEL_ENABLE_RUNC=true` additionally downloads
-the checksum-pinned official runc release and copies both runc binaries into
-the final image.
+`src/distill-fs`, installs the checksum-pinned gVisor `runsc`, and extracts
+the required amd64 artifacts from the checksum-pinned Kata release.
+`AKERNEL_ENABLE_RUNC=true` additionally downloads the checksum-pinned official
+runc release and copies both runc binaries into the final image.
+
+The sandboxd submodule's runtime manifest is the source of truth for the
+gVisor release used by both sandboxd E2E and AKernel packaging. Test an
+unreleased runtime by checking out the sandboxd commit that pins it rather
+than overriding manifest fields from the AKernel build. Keep sandboxd's
+pooled-TAP contract and the matching gVisor compatibility patches validated
+together when upgrading.
 
 The submodule gitlinks are the single source of truth for the sandboxd and
 distill-fs revisions included in a clean release. `make build` always compiles

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ VENDOR ?= aliyun
 ENV ?= default
 IMAGE_TAG ?=
 IMAGE_REPOSITORY ?=
-GVISOR_RELEASE ?=
-GVISOR_RELEASE_BASE_URL ?=
 OPEN_YR_CORE_WHEEL_URL ?=
 OPEN_YR_CORE_WHEEL_SHA256 ?=
 TOKEN_TTL ?= $(if $(TTL),$(TTL),24h)
@@ -52,8 +50,8 @@ help:
 	@echo "  make build IMAGE_TAG=<tag>          Build the all-in-one image"
 	@echo "  make build RUNTIME_PROFILE=python   Include optional Python runtimes"
 	@echo "  make build AKERNEL_ENABLE_KATA=false Exclude the optional Kata payload"
+	@echo "  make build AKERNEL_ENABLE_FIRECRACKER=false Exclude Firecracker"
 	@echo "  make build AKERNEL_ENABLE_RUNC=true Include the optional runc payload"
-	@echo "  make build GVISOR_RELEASE=<tag>     Override the pinned official gVisor tag"
 	@echo "  make versions                       Show locally selected component versions"
 	@echo "  make push                          Push the configured all-in-one image"
 	@echo "  make plan                          Terraform plan"
@@ -102,8 +100,6 @@ build:
 	if [[ -n "$(IMAGE_REPOSITORY)" ]]; then args+=(--repository "$(IMAGE_REPOSITORY)"); fi; \
 	if [[ -n "$(IMAGE_TAG)" ]]; then args+=(--tag "$(IMAGE_TAG)"); fi; \
 	if [[ -n "$(RUNTIME_PROFILE)" ]]; then args+=(--runtime-profile "$(RUNTIME_PROFILE)"); fi; \
-	if [[ -n "$(GVISOR_RELEASE)" ]]; then args+=(--gvisor-release "$(GVISOR_RELEASE)"); fi; \
-	if [[ -n "$(GVISOR_RELEASE_BASE_URL)" ]]; then args+=(--gvisor-release-base-url "$(GVISOR_RELEASE_BASE_URL)"); fi; \
 	if [[ -n "$(OPEN_YR_CORE_WHEEL_URL)" ]]; then args+=(--open-yr-core-wheel-url "$(OPEN_YR_CORE_WHEEL_URL)"); fi; \
 	if [[ -n "$(OPEN_YR_CORE_WHEEL_SHA256)" ]]; then args+=(--open-yr-core-wheel-sha256 "$(OPEN_YR_CORE_WHEEL_SHA256)"); fi; \
 	./deploy/scripts/build-image.sh "$${args[@]}"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ One all-in-one image, multiple deployment targets — deploy in under 10 minutes
 ### Secure Isolation with Extreme Performance
 
 - **40 ms cold start\***: Fork-based launch with lazy loading for near-zero startup latency
-- **Sandbox isolation**: [gVisor](https://github.com/google/gvisor) by default, with [Kata Containers](https://github.com/kata-containers/kata-containers) available on KVM-capable nodes
+- **Sandbox isolation**: [gVisor](https://github.com/google/gvisor) by
+  default, with [Kata Containers](https://github.com/kata-containers/kata-containers)
+  and [Firecracker](https://github.com/firecracker-microvm/firecracker)
+  available on KVM-capable nodes
 - **Checkpoint/Restore\***: Save and restore sandbox state for fast recovery
 
 \* Planned for an open-source release and not available in AKernel v0.1.0.
@@ -157,17 +160,16 @@ with Sandbox(cpu=1000, memory=2048) as sandbox:
     print(sandbox.files.read("/tmp/hello.txt"))
 ```
 
-Experimental gVisor sandboxes can request an exact NVIDIA GPU model and a
-disk-backed writable root filesystem quota:
+Experimental gVisor sandboxes can request an exact NVIDIA GPU model:
 
 ```python
-with Sandbox(xpu="gpu:l20:1", storage_mb=20 * 1024) as sandbox:
+with Sandbox(xpu="gpu:l20:1") as sandbox:
     print(sandbox.commands.run("nvidia-smi -L").stdout)
 ```
 
-GPU sandboxes require a compatible NVIDIA node and currently support only the
-gVisor `runsc` runtime. `storage_mb` is measured in MiB and also currently
-requires `runsc`.
+GPU sandboxes require a compatible NVIDIA node and the gVisor `runsc`
+runtime. `storage_mb` is measured in MiB and is supported by `runsc` and
+Firecracker.
 
 See the complete [basic usage example](./sdk/python/examples/basic_usage.py), the [sandbox runtime example](./sdk/python/examples/sandbox_runtime.py), and the other [SDK examples](./sdk/python/examples/) for more operations.
 
@@ -178,9 +180,8 @@ See the complete [basic usage example](./sdk/python/examples/basic_usage.py), th
 ### System Components
 
 **Node-Level Infrastructure**
-- **Sandbox runtimes**: gVisor by default, including experimental NVIDIA GPU
-  and writable-storage support; Kata Containers on KVM-capable nodes; and an
-  explicitly enabled native Linux runc backend
+- **Sandbox runtimes**: gVisor by default; Kata Containers and Firecracker on
+  KVM-capable nodes; and an explicitly enabled native Linux runc backend
 - **sandboxd**: Sandbox lifecycle daemon with pluggable sandbox runtime integration
 - **distill-fs**: Rust-based FUSE filesystem for lazy rootfs access, chunk caching, and deduplication
 
@@ -202,6 +203,7 @@ See the complete [basic usage example](./sdk/python/examples/basic_usage.py), th
 ## Roadmap
 
 - [x] Kata Containers runtime on KVM-capable nodes
+- [x] Firecracker microVM runtime on KVM-capable nodes
 - [x] Optional native Linux runc runtime
 - [x] Sandbox network ACL
 - [ ] Fork-based sandbox launch based on gVisor

--- a/builder/node.Dockerfile
+++ b/builder/node.Dockerfile
@@ -7,6 +7,7 @@ ARG AKERNEL_RUNTIME_IMAGE=akernel-runtime:local
 ARG AKERNEL_RUNTIME_PROFILE=rrt
 ARG AKERNEL_ENABLE_KATA=true
 ARG AKERNEL_ENABLE_RUNC=false
+ARG AKERNEL_ENABLE_FIRECRACKER=true
 ARG SANDBOXD_BUILD_IMAGE=golang:1.25.5-bookworm
 ARG DISTILL_FS_BUILD_IMAGE=rust:1.85.0-bookworm
 ARG OPEN_YR_VERSION=0.9.9
@@ -28,6 +29,10 @@ ARG KATA_BUILD_IMAGE=ubuntu:24.04
 ARG KATA_RELEASE=4.0.0
 ARG KATA_AMD64_SHA256=2c3b9dfeba355582b40aee462b12916c9740654d0230f696adf719d67b063a8c
 ARG KATA_RELEASE_BASE_URL=https://github.com/kata-containers/kata-containers/releases/download
+ARG FIRECRACKER_BUILD_IMAGE=ubuntu:24.04
+ARG FIRECRACKER_RELEASE
+ARG FIRECRACKER_AMD64_SHA256
+ARG FIRECRACKER_AMD64_URL
 ARG OTELCOL_CONTRIB_VERSION=0.120.0
 ARG OTELCOL_CONTRIB_URL=https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${OTELCOL_CONTRIB_VERSION}/otelcol-contrib_${OTELCOL_CONTRIB_VERSION}_linux_amd64.tar.gz
 ARG AKERNEL_VERSION=unknown
@@ -109,6 +114,63 @@ WORKDIR /src/sandboxd
 COPY ./src/sandboxd/ ./
 RUN make release
 
+FROM ${FIRECRACKER_BUILD_IMAGE} AS firecracker-runtime-true
+ARG FIRECRACKER_RELEASE
+ARG FIRECRACKER_AMD64_SHA256
+ARG FIRECRACKER_AMD64_URL
+ARG TARGETARCH
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates cpio curl gzip jq && \
+    rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    test "${TARGETARCH:-amd64}" = "amd64"; \
+    test -n "${FIRECRACKER_RELEASE}"; \
+    test -n "${FIRECRACKER_AMD64_SHA256}"; \
+    test -n "${FIRECRACKER_AMD64_URL}"; \
+    archive="/tmp/firecracker-${FIRECRACKER_RELEASE}-x86_64.tgz"; \
+    curl -fSL --retry 10 --retry-delay 2 --retry-all-errors \
+      "${FIRECRACKER_AMD64_URL}" \
+      -o "${archive}"; \
+    echo "${FIRECRACKER_AMD64_SHA256}  ${archive}" | sha256sum -c -; \
+    mkdir -p /tmp/firecracker-release \
+      /firecracker/usr/local/bin \
+      /firecracker/opt/firecracker/licenses \
+      /initrd; \
+    tar -xzf "${archive}" -C /tmp/firecracker-release; \
+    bundle="/tmp/firecracker-release/release-${FIRECRACKER_RELEASE}-x86_64"; \
+    jq -e --arg release "${FIRECRACKER_RELEASE}" \
+      '.component == "akernel-firecracker-runtime" and \
+       .repository == "akernel-dev/firecracker" and \
+       .release_tag == $release and \
+       .architecture == "x86_64"' \
+      "${bundle}/manifest.json" >/dev/null; \
+    (cd "${bundle}"; sha256sum -c SHA256SUMS); \
+    install -m 0755 "${bundle}/firecracker" \
+      /firecracker/usr/local/bin/firecracker; \
+    install -m 0644 \
+      "${bundle}/vmlinux" \
+      "${bundle}/kernel.config" \
+      "${bundle}/manifest.json" \
+      /firecracker/opt/firecracker/; \
+    cp -a "${bundle}/licenses/." /firecracker/opt/firecracker/licenses/
+
+COPY --from=sandboxd-builder /src/sandboxd/output/firecracker-agent /initrd/init
+RUN set -eux; \
+    chmod 0755 /initrd/init; \
+    chmod 0700 /initrd; \
+    touch -d @0 /initrd /initrd/init; \
+    cd /initrd; \
+    find . -print0 \
+      | LC_ALL=C sort -z \
+      | cpio --null --create --format=newc --owner=0:0 --reproducible \
+      | gzip -n -9 > /firecracker/opt/firecracker/initrd.img; \
+    chmod 0644 /firecracker/opt/firecracker/initrd.img
+
+FROM ${FIRECRACKER_BUILD_IMAGE} AS firecracker-runtime-false
+RUN mkdir -p /firecracker/usr/local/bin /firecracker/opt/firecracker
+
+FROM firecracker-runtime-${AKERNEL_ENABLE_FIRECRACKER} AS firecracker-runtime
+
 FROM ${RUNC_BUILD_IMAGE} AS runc-runtime-true
 ARG RUNC_VERSION
 ARG RUNC_AMD64_SHA256
@@ -154,6 +216,7 @@ RUN cargo build --locked --release --bin distill_fs
 FROM ${AKERNEL_NODE_BASE_IMAGE}
 ARG AKERNEL_ENABLE_KATA
 ARG AKERNEL_ENABLE_RUNC
+ARG AKERNEL_ENABLE_FIRECRACKER
 ARG AKERNEL_RUNTIME_PROFILE
 ARG AKERNEL_VERSION
 ARG AKERNEL_REVISION
@@ -165,6 +228,7 @@ ARG OPEN_YR_CORE_AMD64_SHA256
 ARG OPEN_YR_CORE_ARM64_SHA256
 ARG GVISOR_RELEASE
 ARG RUNC_VERSION
+ARG FIRECRACKER_RELEASE
 ARG LIBNVIDIA_CONTAINER_VERSION
 ARG OTELCOL_CONTRIB_URL
 ARG TARGETARCH
@@ -285,6 +349,7 @@ COPY --from=sandboxd-builder /src/sandboxd/output/sandbox-logger /usr/local/bin/
 COPY --from=distill-fs-builder /src/distill-fs/target/release/distill_fs /usr/local/bin/distill_fs
 COPY --from=kata-runtime /kata/opt/kata /opt/kata
 COPY --from=runc-runtime /runc/usr/local/bin/ /usr/local/bin/
+COPY --from=firecracker-runtime /firecracker/ /
 RUN if [ "${AKERNEL_ENABLE_KATA}" = "true" ]; then \
       ln -sf /opt/kata/runtime-rs/bin/containerd-shim-kata-v2 /usr/local/bin/containerd-shim-kata-v2; \
     fi
@@ -350,7 +415,9 @@ LABEL org.opencontainers.image.version="${AKERNEL_VERSION}" \
       org.akernel.gvisor.release="${GVISOR_RELEASE}" \
       org.akernel.runc.version="${RUNC_VERSION}" \
       org.akernel.runc.enabled="${AKERNEL_ENABLE_RUNC}" \
-      org.akernel.kata.enabled="${AKERNEL_ENABLE_KATA}"
+      org.akernel.kata.enabled="${AKERNEL_ENABLE_KATA}" \
+      org.akernel.firecracker.release="${FIRECRACKER_RELEASE}" \
+      org.akernel.firecracker.enabled="${AKERNEL_ENABLE_FIRECRACKER}"
 
 ENV YR_LOG_PATH=${YR_INSTALLATION_DIR}/logs
 STOPSIGNAL SIGRTMIN+3

--- a/builder/node.Dockerfile
+++ b/builder/node.Dockerfile
@@ -15,8 +15,10 @@ ARG OPEN_YR_CORE_WHEEL_SHA256=
 ARG OPEN_YR_RELEASE_BASE_URL=https://github.com/openYuanrong-mirror/yuanrong/releases/download
 ARG OPEN_YR_CORE_AMD64_SHA256=c2c0c37d985b07c0543c402534380fa84b1b7a5883bbb25d5d332bf97fa8c2ba
 ARG OPEN_YR_CORE_ARM64_SHA256=2b751a856cf0545a11bff0bbe987eb91ea5d8184859c16fa601398211e7f4301
-ARG GVISOR_RELEASE=release-20260706.0
-ARG GVISOR_RELEASE_BASE_URL=https://storage.googleapis.com/gvisor/releases
+ARG GVISOR_DOWNLOAD_IMAGE=ubuntu:24.04
+ARG GVISOR_RELEASE
+ARG GVISOR_AMD64_URL
+ARG GVISOR_AMD64_SHA512
 ARG RUNC_VERSION=1.5.1
 ARG RUNC_AMD64_SHA256=177df879d50c913eb205e898d5c1c05a18f574053c0ce5524c471208eaf06f6f
 ARG RUNC_RELEASE_BASE_URL=https://github.com/opencontainers/runc/releases/download
@@ -30,6 +32,30 @@ ARG OTELCOL_CONTRIB_VERSION=0.120.0
 ARG OTELCOL_CONTRIB_URL=https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${OTELCOL_CONTRIB_VERSION}/otelcol-contrib_${OTELCOL_CONTRIB_VERSION}_linux_amd64.tar.gz
 ARG AKERNEL_VERSION=unknown
 ARG AKERNEL_REVISION=unknown
+
+FROM ${GVISOR_DOWNLOAD_IMAGE} AS gvisor-runtime
+ARG GVISOR_RELEASE
+ARG GVISOR_AMD64_URL
+ARG GVISOR_AMD64_SHA512
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH:-}" in \
+      amd64) ;; \
+      "") test "$(uname -m)" = "x86_64" ;; \
+      *) echo "unsupported gVisor target architecture: ${TARGETARCH}" >&2; \
+         exit 1 ;; \
+    esac; \
+    test -n "${GVISOR_RELEASE}"; \
+    test -n "${GVISOR_AMD64_URL}"; \
+    test -n "${GVISOR_AMD64_SHA512}"; \
+    asset=/tmp/runsc; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    rm -rf /var/lib/apt/lists/*; \
+    curl -fSL --retry 10 --retry-delay 2 --retry-all-errors \
+      "${GVISOR_AMD64_URL}" -o "${asset}"; \
+    echo "${GVISOR_AMD64_SHA512}  ${asset}" | sha512sum -c -; \
+    install -D -m 0755 "${asset}" /gvisor/runsc
 
 FROM ${KATA_BUILD_IMAGE} AS kata-runtime-true
 ARG KATA_RELEASE
@@ -138,7 +164,6 @@ ARG OPEN_YR_RELEASE_BASE_URL
 ARG OPEN_YR_CORE_AMD64_SHA256
 ARG OPEN_YR_CORE_ARM64_SHA256
 ARG GVISOR_RELEASE
-ARG GVISOR_RELEASE_BASE_URL
 ARG RUNC_VERSION
 ARG LIBNVIDIA_CONTAINER_VERSION
 ARG OTELCOL_CONTRIB_URL
@@ -189,28 +214,6 @@ RUN if command -v update-alternatives >/dev/null 2>&1; then \
         update-alternatives --set iptables /usr/sbin/iptables-legacy || true; \
         update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || true; \
     fi
-
-RUN set -eux; \
-    case "${TARGETARCH:-}" in \
-        amd64) gvisor_arch="x86_64" ;; \
-        "") \
-            [ "$(uname -m)" = "x86_64" ] || { echo "unsupported gVisor target architecture: $(uname -m)" >&2; exit 1; }; \
-            gvisor_arch="x86_64" ;; \
-        *) echo "unsupported gVisor target architecture: ${TARGETARCH}" >&2; exit 1 ;; \
-    esac; \
-    gvisor_version="${GVISOR_RELEASE#release-}"; \
-    if [ "${gvisor_version}" = "${GVISOR_RELEASE}" ]; then \
-        echo "GVISOR_RELEASE must be an official tag such as release-20260706.0" >&2; \
-        exit 1; \
-    fi; \
-    gvisor_url="${GVISOR_RELEASE_BASE_URL}/release/${gvisor_version}/${gvisor_arch}"; \
-    mkdir -p /tmp/gvisor-release; \
-    cd /tmp/gvisor-release; \
-    curl -fSLO --retry 10 --retry-delay 2 --retry-all-errors "${gvisor_url}/runsc"; \
-    curl -fSLO --retry 10 --retry-delay 2 --retry-all-errors "${gvisor_url}/runsc.sha512"; \
-    sha512sum -c runsc.sha512; \
-    install -m 0755 runsc /usr/local/bin/runsc; \
-    rm -rf /tmp/gvisor-release
 
 RUN if command -v systemctl >/dev/null 2>&1; then \
         systemctl mask \
@@ -275,6 +278,7 @@ RUN set -eux; \
 
 COPY --from=runtime-image /yr-runtime-rootfs.img ${YR_INSTALLATION_DIR}/yr-runtime-rootfs.img
 
+COPY --from=gvisor-runtime /gvisor/runsc /usr/local/bin/runsc
 COPY --from=sandboxd-builder /src/sandboxd/output/sandboxd /usr/local/bin/sandboxd
 COPY --from=sandboxd-builder /src/sandboxd/output/sbox /usr/local/bin/sbox
 COPY --from=sandboxd-builder /src/sandboxd/output/sandbox-logger /usr/local/bin/sandbox-logger
@@ -343,6 +347,7 @@ RUN mkdir -p ${YR_INSTALLATION_DIR}/logs ${YR_INSTALLATION_DIR}/metrics ${YR_INS
 LABEL org.opencontainers.image.version="${AKERNEL_VERSION}" \
       org.opencontainers.image.revision="${AKERNEL_REVISION}" \
       org.akernel.runtime.profile="${AKERNEL_RUNTIME_PROFILE}" \
+      org.akernel.gvisor.release="${GVISOR_RELEASE}" \
       org.akernel.runc.version="${RUNC_VERSION}" \
       org.akernel.runc.enabled="${AKERNEL_ENABLE_RUNC}" \
       org.akernel.kata.enabled="${AKERNEL_ENABLE_KATA}"

--- a/builder/scripts/sandboxd_network_prepare.sh
+++ b/builder/scripts/sandboxd_network_prepare.sh
@@ -44,6 +44,11 @@ enable_local_dnat="$(network_value enable_local_dnat)"
 enable_network_acl="$(network_value enable_network_acl)"
 nat_backend="${nat_backend:-iptables}"
 
+if [[ ! -c /dev/net/tun ]]; then
+    echo "/dev/net/tun is unavailable; load the host tun module before starting the AKernel node" >&2
+    exit 1
+fi
+
 # Both NAT backends route packets between sandbox0 and the selected external
 # interface. AKernel owns this network-namespace prerequisite.
 "${SYSCTL_BIN}" -w net.ipv4.ip_forward=1

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -25,7 +25,17 @@ make print-env
 make e2e
 ```
 
-Kata Containers is enabled in the default AKernel runtime configuration and adds one host requirement: `/dev/kvm` must be available to the node container. Nodes without a usable KVM device remain ready and advertise only runsc. If no node advertises Kata, `Sandbox(runtime="kata")` fails scheduling with a no-resource error.
+Kata Containers and Firecracker are enabled in the default AKernel image and
+runtime configuration. Both require `/dev/kvm` to be available to the node
+container. Nodes without a usable KVM device remain ready for runsc workloads
+and do not advertise either VM runtime. If no eligible node advertises a
+requested runtime, `Sandbox(runtime="kata")` or
+`Sandbox(runtime="firecracker")` fails scheduling with a no-resource error.
+
+The bundled Firecracker payload is selected by sandboxd's shared runtime
+manifest. Set `AKERNEL_ENABLE_FIRECRACKER=false` while building to exclude it.
+For supported operations and filesystem constraints, see the
+[sandbox runtime comparison](https://github.com/inclusionAI/sandboxd/blob/1918fadb03b59bc6f540196e14b90a91bdf31b7d/doc/runtime.md).
 
 The native Linux runc backend is opt-in because it uses the host kernel. For a
 guided cloud profile, `make config ENABLE_RUNC=true` records both sides of the
@@ -44,9 +54,11 @@ the sandbox bridge when their `FORWARD` policy is `DROP`.
 ### Network ACLs
 
 The bundled standalone, Helm, and Terraform sandboxd configurations enable
-per-sandbox network ACLs. A sandbox created without a policy remains on the
-unrestricted fast path. The default `iptables` backend requires `ip_tables`,
-`br_netfilter`, conntrack, connmark/CONNMARK support, and
+per-sandbox network ACLs. Runsc, Kata, and Firecracker require the host `tun`
+module and a usable `/dev/net/tun` for their pooled TAP endpoints. A sandbox
+created without a policy remains on the unrestricted fast path. The default
+`iptables` backend additionally requires `ip_tables`, `br_netfilter`,
+conntrack, connmark/CONNMARK support, and
 `net.bridge.bridge-nf-call-iptables=1`. The optional `bpfnat` backend instead
 requires Linux eBPF `SCHED_CLS`, TC `clsact`, supported hash and array maps, a
 writable bpffs at `/sys/fs/bpf` (or permission to mount one), and permission

--- a/deploy/akernel/charts/core/values.yaml
+++ b/deploy/akernel/charts/core/values.yaml
@@ -492,10 +492,12 @@ node:
         [plugin.runtime.basic_spec]
         runsc="/home/akernel/images/config.json"
         runc=""
+        firecracker="/home/akernel/images/config.json"
 
         [plugin.runtime.runtime_binary]
         runsc="/usr/local/bin/runsc"
         kata="/usr/local/bin/containerd-shim-kata-v2"
+        firecracker="/usr/local/bin/firecracker"
         # AKERNEL_RUNTIME_RUNC
 
         [plugin.runtime.kata]

--- a/deploy/scripts/build-image.sh
+++ b/deploy/scripts/build-image.sh
@@ -24,6 +24,9 @@ source "${runtime_versions_file}"
 gvisor_release="${GVISOR_RELEASE:-}"
 gvisor_amd64_sha512="${GVISOR_AMD64_SHA512:-}"
 gvisor_amd64_url="${GVISOR_AMD64_URL:-}"
+firecracker_release="${FIRECRACKER_RELEASE:-}"
+firecracker_amd64_sha256="${FIRECRACKER_AMD64_SHA256:-}"
+firecracker_amd64_url="${FIRECRACKER_AMD64_URL:-}"
 open_yr_core_wheel_url="${OPEN_YR_CORE_WHEEL_URL:-}"
 open_yr_core_wheel_sha256="${OPEN_YR_CORE_WHEEL_SHA256:-}"
 print_component_versions=0
@@ -196,6 +199,16 @@ node_build_args+=(
   --build-arg "GVISOR_RELEASE=${gvisor_release}"
   --build-arg "GVISOR_AMD64_URL=${gvisor_amd64_url}"
   --build-arg "GVISOR_AMD64_SHA512=${gvisor_amd64_sha512}"
+)
+if [[ -z "${firecracker_release}" ||
+      -z "${firecracker_amd64_sha256}" ||
+      -z "${firecracker_amd64_url}" ]]; then
+  die "FIRECRACKER_RELEASE, FIRECRACKER_AMD64_URL, and FIRECRACKER_AMD64_SHA256 must be set together"
+fi
+node_build_args+=(
+  --build-arg "FIRECRACKER_RELEASE=${firecracker_release}"
+  --build-arg "FIRECRACKER_AMD64_URL=${firecracker_amd64_url}"
+  --build-arg "FIRECRACKER_AMD64_SHA256=${firecracker_amd64_sha256}"
 )
 if [[ -n "${open_yr_core_wheel_url}" || -n "${open_yr_core_wheel_sha256}" ]]; then
   if [[ -z "${open_yr_core_wheel_url}" || -z "${open_yr_core_wheel_sha256}" ]]; then

--- a/deploy/scripts/build-image.sh
+++ b/deploy/scripts/build-image.sh
@@ -15,8 +15,15 @@ tag=""
 env_name=""
 runtime_image=""
 runtime_profile="${RUNTIME_PROFILE:-rrt}"
-gvisor_release=""
-gvisor_release_base_url=""
+runtime_versions_file="${ROOT}/src/sandboxd/third_party/runtime-versions.env"
+if [[ ! -f "${runtime_versions_file}" ]]; then
+  die "missing runtime version manifest: ${runtime_versions_file}"
+fi
+# shellcheck source=/dev/null
+source "${runtime_versions_file}"
+gvisor_release="${GVISOR_RELEASE:-}"
+gvisor_amd64_sha512="${GVISOR_AMD64_SHA512:-}"
+gvisor_amd64_url="${GVISOR_AMD64_URL:-}"
 open_yr_core_wheel_url="${OPEN_YR_CORE_WHEEL_URL:-}"
 open_yr_core_wheel_sha256="${OPEN_YR_CORE_WHEEL_SHA256:-}"
 print_component_versions=0
@@ -83,14 +90,6 @@ while [[ $# -gt 0 ]]; do
       runtime_profile="$2"
       shift 2
       ;;
-    --gvisor-release)
-      gvisor_release="$2"
-      shift 2
-      ;;
-    --gvisor-release-base-url)
-      gvisor_release_base_url="$2"
-      shift 2
-      ;;
     --open-yr-core-wheel-url)
       open_yr_core_wheel_url="$2"
       shift 2
@@ -117,6 +116,11 @@ esac
 case "${AKERNEL_ENABLE_KATA:-true}" in
   true|false) ;;
   *) die "AKERNEL_ENABLE_KATA must be true or false" ;;
+esac
+
+case "${AKERNEL_ENABLE_FIRECRACKER:-true}" in
+  true|false) ;;
+  *) die "AKERNEL_ENABLE_FIRECRACKER must be true or false" ;;
 esac
 
 require_cmd docker
@@ -179,15 +183,20 @@ node_build_args=(
   --build-arg "AKERNEL_RUNTIME_PROFILE=${runtime_profile}"
   --build-arg "AKERNEL_ENABLE_KATA=${AKERNEL_ENABLE_KATA:-true}"
   --build-arg "AKERNEL_ENABLE_RUNC=${AKERNEL_ENABLE_RUNC:-false}"
+  --build-arg "AKERNEL_ENABLE_FIRECRACKER=${AKERNEL_ENABLE_FIRECRACKER:-true}"
   --build-arg "AKERNEL_VERSION=${akernel_version}"
   --build-arg "AKERNEL_REVISION=${akernel_revision}"
 )
-if [[ -n "${gvisor_release}" ]]; then
-  node_build_args+=(--build-arg "GVISOR_RELEASE=${gvisor_release}")
+if [[ -z "${gvisor_release}" ||
+      -z "${gvisor_amd64_sha512}" ||
+      -z "${gvisor_amd64_url}" ]]; then
+  die "GVISOR_RELEASE, GVISOR_AMD64_URL, and GVISOR_AMD64_SHA512 must be set together"
 fi
-if [[ -n "${gvisor_release_base_url}" ]]; then
-  node_build_args+=(--build-arg "GVISOR_RELEASE_BASE_URL=${gvisor_release_base_url}")
-fi
+node_build_args+=(
+  --build-arg "GVISOR_RELEASE=${gvisor_release}"
+  --build-arg "GVISOR_AMD64_URL=${gvisor_amd64_url}"
+  --build-arg "GVISOR_AMD64_SHA512=${gvisor_amd64_sha512}"
+)
 if [[ -n "${open_yr_core_wheel_url}" || -n "${open_yr_core_wheel_sha256}" ]]; then
   if [[ -z "${open_yr_core_wheel_url}" || -z "${open_yr_core_wheel_sha256}" ]]; then
     die "OPEN_YR_CORE_WHEEL_URL and OPEN_YR_CORE_WHEEL_SHA256 must be set together"

--- a/deploy/standalone/README.md
+++ b/deploy/standalone/README.md
@@ -12,7 +12,15 @@ Keeping the gateway in a separate network namespace allows sandboxd's normal
 traffic from the node network namespace, so the standalone sandboxd config
 also enables its local-output DNAT support.
 
-The default runtime is gVisor `runsc`. `Sandbox(runtime="kata")` additionally requires `/dev/kvm` and hardware or nested virtualization on the Docker host. Nodes without KVM remain usable with runsc and do not advertise Kata to the scheduler.
+The default runtime is gVisor `runsc`. The bundled image also contains Kata
+Containers and Firecracker. Both `Sandbox(runtime="kata")` and
+`Sandbox(runtime="firecracker")` require `/dev/kvm` plus hardware or nested
+virtualization on the Docker host. Nodes without KVM remain usable with runsc
+and do not advertise either VM runtime to the scheduler.
+
+See the maintained
+[runtime selection example](../../sdk/python/examples/sandbox_runtime.py) for
+client usage.
 
 Default image builds exclude the optional native Linux `runc` runtime, and
 standalone does not advertise it by default. Build an image containing the
@@ -41,11 +49,16 @@ The all-in-one image contains `nvidia-container-cli`, but not the host driver.
 Use `AKERNEL_GPU_DEVICES` to override Docker's `--gpus` value when only a
 device subset should be assigned.
 
-Explicit sandbox storage quotas use the bounded ext4 filestore mounted at
-`/home/akernel/filestore`. The standalone data directory is bind-mounted from
-the host, and sandboxd creates a loop-backed filesystem image there when
-needed; quota-backed writable layers therefore use local disk rather than
-tmpfs.
+Explicit sandbox storage quotas for runsc and Firecracker use the bounded ext4
+filestore mounted at `/home/akernel/filestore`. The standalone data directory
+is bind-mounted from the host, and sandboxd creates a loop-backed filesystem
+image there when needed; quota-backed writable layers therefore use local disk
+rather than tmpfs. Without `storage_mb`, runsc retains its configured
+memory-backed overlay while Firecracker uses its configured sparse ext4
+default.
+
+`start.sh` loads the host `tun` module and verifies `/dev/net/tun` before
+starting the pooled-TAP runtimes. Runc retains its separate veth network path.
 
 ### Network backend
 

--- a/deploy/standalone/config/sandboxd_config.toml
+++ b/deploy/standalone/config/sandboxd_config.toml
@@ -42,10 +42,12 @@ overlay_tmpfs_size="10G"
 [plugin.runtime.basic_spec]
 runsc="/home/akernel/images/config.json"
 runc=""
+firecracker="/home/akernel/images/config.json"
 
 [plugin.runtime.runtime_binary]
 runsc="/usr/local/bin/runsc"
 kata="/usr/local/bin/containerd-shim-kata-v2"
+firecracker="/usr/local/bin/firecracker"
 # AKERNEL_RUNTIME_RUNC
 
 [plugin.runtime.kata]

--- a/deploy/standalone/start.sh
+++ b/deploy/standalone/start.sh
@@ -80,9 +80,9 @@ check_prerequisites() {
     log_info "${DOCKER_CMD} is available"
 
     if [[ ! -c /dev/kvm ]]; then
-        log_warn "/dev/kvm is unavailable; standalone will support runsc but will not advertise the Kata runtime"
+        log_warn "/dev/kvm is unavailable; standalone will support runsc but will not advertise Kata or Firecracker"
     elif [[ ! -r /dev/kvm || ! -w /dev/kvm ]]; then
-        log_warn "/dev/kvm is not accessible to the current user; verify that the privileged node container can access it before using Kata"
+        log_warn "/dev/kvm is not accessible to the current user; verify that the privileged node container can access it before using Kata or Firecracker"
     fi
 
     if ! command -v curl &> /dev/null; then
@@ -282,15 +282,29 @@ configure_network() {
 }
 
 prepare_host_network_modules() {
-    if [[ "${AKERNEL_NAT_BACKEND}" != "iptables" ]]; then
-        return 0
-    fi
-
     local modprobe_bin
     modprobe_bin="$(command -v modprobe || true)"
     if [[ -z "${modprobe_bin}" ]]; then
-        log_error "modprobe is required to load br_netfilter for the iptables ACL backend"
+        log_error "modprobe is required to load AKernel host network modules"
         exit 1
+    fi
+
+    if [[ "$(id -u)" -eq 0 ]]; then
+        "${modprobe_bin}" tun
+    elif sudo -n "${modprobe_bin}" tun; then
+        :
+    else
+        log_error "Unable to load tun; run this script as root or allow passwordless sudo for modprobe"
+        exit 1
+    fi
+    if [[ ! -c /dev/net/tun ]]; then
+        log_error "tun loaded but /dev/net/tun is unavailable"
+        exit 1
+    fi
+    log_info "Loaded host tun module for pooled TAP networking"
+
+    if [[ "${AKERNEL_NAT_BACKEND}" != "iptables" ]]; then
+        return 0
     fi
 
     if [[ "$(id -u)" -eq 0 ]]; then

--- a/deploy/terraform/aliyun/values-akernel.yaml.tmpl
+++ b/deploy/terraform/aliyun/values-akernel.yaml.tmpl
@@ -202,10 +202,12 @@ node:
         [plugin.runtime.basic_spec]
         runsc="/home/akernel/images/config.json"
         runc=""
+        firecracker="/home/akernel/images/config.json"
 
         [plugin.runtime.runtime_binary]
         runsc="/usr/local/bin/runsc"
         kata="/usr/local/bin/containerd-shim-kata-v2"
+        firecracker="/usr/local/bin/firecracker"
         # AKERNEL_RUNTIME_RUNC
 
         [plugin.runtime.kata]

--- a/deploy/terraform/huaweicloud/values-akernel.yaml.tmpl
+++ b/deploy/terraform/huaweicloud/values-akernel.yaml.tmpl
@@ -160,10 +160,12 @@ node:
         [plugin.runtime.basic_spec]
         runsc="/home/akernel/images/config.json"
         runc=""
+        firecracker="/home/akernel/images/config.json"
 
         [plugin.runtime.runtime_binary]
         runsc="/usr/local/bin/runsc"
         kata="/usr/local/bin/containerd-shim-kata-v2"
+        firecracker="/usr/local/bin/firecracker"
         # AKERNEL_RUNTIME_RUNC
 
         [plugin.runtime.kata]

--- a/deploy/terraform/shared/node-bootstrap.sh.tftpl
+++ b/deploy/terraform/shared/node-bootstrap.sh.tftpl
@@ -5,6 +5,27 @@
 # SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
+# Pooled TAP endpoints require the host TUN driver and device before kubelet
+# starts the privileged AKernel node container.
+cat >/etc/systemd/system/akernel-tun-module.service <<'EOF'
+[Unit]
+Description=Load TUN module for AKernel pooled TAP networking
+After=systemd-modules-load.service
+Before=kubelet.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'modprobe tun && test -c /dev/net/tun'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable akernel-tun-module.service
+systemctl start akernel-tun-module.service
+
 %{ if sandboxd_nat_backend == "iptables" ~}
 # ip_tables provides NAT and br_netfilter provides bridged ACL enforcement.
 cat >/etc/systemd/system/akernel-network-modules.service <<'EOF'

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -204,18 +204,14 @@ AKernel uses the gVisor `runsc` runtime when `runtime` is omitted. Runtime
 identifiers and optional `extra_config` are forwarded to the selected backend
 instead of being restricted or interpreted by an SDK-owned registry. Values in
 `extra_config` must be JSON-compatible. The bundled deployment advertises
-`runsc` and Kata Containers by default:
+`runsc`, Kata Containers, and Firecracker by default when their host
+prerequisites are available.
 
-```python
-default_sandbox = Sandbox()
-runsc_sandbox = Sandbox(runtime="runsc")
-kata_sandbox = Sandbox(runtime="kata")
-```
-
-Kata requires at least one cluster node whose sandboxd instance successfully
-initialized the Kata runtime with a usable `/dev/kvm` device. Nodes without
-KVM remain available for runsc workloads and do not advertise Kata. A runtime
-that is unavailable in the cluster fails scheduling or backend validation.
+Kata and Firecracker require at least one cluster node whose sandboxd instance
+successfully initialized the requested runtime with a usable `/dev/kvm`
+device. Nodes without KVM remain available for runsc workloads and do not
+advertise either VM runtime. Firecracker accepts EROFS image roots and mounts
+and rejects OCI/Nydus directories, directory mounts, GPUs, and nested KVM.
 
 The all-in-one image can optionally package a native Linux `runc` backend.
 Operators build it with `AKERNEL_ENABLE_RUNC=true` and enable it explicitly
@@ -239,7 +235,8 @@ with Sandbox(
 `enableKVM` is owned by the runc backend and requires a usable `/dev/kvm` on
 the selected node. Runc supports OCI/EROFS root filesystems, read-only mounts,
 networking, command execution, and the default writable overlay. Experimental
-GPU requests and explicit `storage_mb` quotas remain runsc-only. See the
+GPU requests remain runsc-only; explicit `storage_mb` quotas are supported by
+runsc and Firecracker. See the
 [sandbox runtime comparison](../../src/sandboxd/doc/runtime.md) for the
 runtime capability boundaries.
 
@@ -424,6 +421,10 @@ runtime inside an S3 object. When neither source is supplied, AKernel sends
 only the selected isolation runtime and openYuanRong overlays it onto the
 rootfs configured by the deployed service.
 
+For Firecracker, the deployed default or an explicit `rootfs` object must be a
+raw EROFS image. `image="ubuntu:24.04"` produces an OCI/Nydus directory and is
+therefore supported by runsc, runc, and Kata but rejected by Firecracker.
+
 The same `S3Config` type can be used as a read-only mount source:
 
 ```python
@@ -439,6 +440,9 @@ OCI images can also be mounted read-only:
 ```python
 mount = Mount(target="/opt/tools", image_url="ubuntu:24.04")
 ```
+
+Firecracker mounts must instead use `type="erofs"` with an S3 object containing
+a raw EROFS image; it rejects `image_url` and directory-backed mounts.
 
 ## Launch from a Dockerfile
 

--- a/sdk/python/examples/sandbox_runtime.py
+++ b/sdk/python/examples/sandbox_runtime.py
@@ -14,8 +14,10 @@
 
 """Select a sandbox runtime.
 
-The Kata case requires at least one cluster node that advertises Kata support.
-Otherwise, the scheduler returns a no-resource error.
+The Kata and Firecracker cases require at least one cluster node that
+advertises the respective KVM-backed runtime. The Firecracker case uses the
+deployment's default EROFS root; OCI/Nydus directory images are not supported
+by that runtime.
 Set AKERNEL_EXAMPLE_RUNC=true to include the optional runc runtime.
 """
 
@@ -44,6 +46,7 @@ def main() -> None:
     run(None)
     run("runsc")
     run("kata")
+    run("firecracker")
     if os.environ.get("AKERNEL_EXAMPLE_RUNC", "").lower() == "true":
         run("runc")
 


### PR DESCRIPTION
## Summary

Consume sandboxd's shared runtime manifest as the source of truth for the
compatible gVisor and Firecracker releases.

Package the checksum-verified Firecracker runtime bundle, build its matching
guest-agent initrd, and enable the runtime in standalone, Helm, and Terraform
deployments. Firecracker accepts read-only EROFS roots and mounts, with a
private ext4 writable layer for each sandbox.

Update the runtime documentation and examples to describe KVM requirements,
capability discovery, storage behavior, and unsupported inputs.

## Testing

- `make sdk-check`
- `make deploy-script-check`
- `make versions`
- AKernel standalone Firecracker command, process, filesystem, PTY, storage,
  recovery, and reverse-tunnel coverage
- Firecracker EROFS lazy loading through distill-fs against an S3-compatible
  range server
- sandboxd runtime and network E2E coverage in inclusionAI/sandboxd#27
