### PR TITLE
fix(runtime): preserve packaged static tini

### DIFF
--- a/builder/runtime.Dockerfile
+++ b/builder/runtime.Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && \
         libgcc-s1 \
         tini && \
     rm -rf /var/lib/apt/lists/* && \
-    cp /usr/bin/tini /usr/bin/tini-static && \
+    test -x /usr/bin/tini-static && \
     /usr/bin/tini-static --version
 
 RUN mkdir -p /var/task/code /__yuanrong && \


### PR DESCRIPTION
## Summary

Stop overwriting Ubuntu's packaged static tini binary with the dynamically
linked `/usr/bin/tini` executable.

Require `/usr/bin/tini-static` to exist and be executable during the runtime
image build before running the existing version smoke check.

## Testing

- `git diff --check`
- Verified the Ubuntu Noble `tini` package provides an executable, statically
  linked `/usr/bin/tini-static`
