### PR TITLE
fix(sdk): decouple exec from gateway address

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,8 +345,10 @@ export AKERNEL_SERVER_ADDRESS=<traefik-container-ip>
 ```
 
 No separate `AKERNEL_GATEWAY_ADDRESS` is required for the default standalone
-layout. Standalone uses `akerneldev/all-in-one:latest` by default; pass `IMAGE`
-to test a locally built or differently tagged image.
+layout. When a custom topology sets it, the override applies only to public
+sandbox port URLs and reverse tunnels; exec and file transfer continue to use
+`AKERNEL_SERVER_ADDRESS`. Standalone uses `akerneldev/all-in-one:latest` by
+default; pass `IMAGE` to test a locally built or differently tagged image.
 
 Standalone GPU testing additionally requires NVIDIA Container Toolkit on the
 host and `AKERNEL_ENABLE_GPU=true`. sandboxd uses the read-only cgroup

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -56,8 +56,10 @@ Address behavior is deterministic:
 - A host or IP without a port uses HTTPS/WSS on 443 for the frontend and HTTP
   on 80 for public sandbox port URLs.
 - `host:port` uses that port as a shared HTTPS/WSS endpoint.
-- `AKERNEL_GATEWAY_ADDRESS` overrides the port-forwarding and exec gateway for
-  standalone or custom topologies. An override without a scheme uses HTTP/WS.
+- `AKERNEL_GATEWAY_ADDRESS` overrides only the port-forwarding and reverse
+  tunnel gateway for standalone or custom topologies. An override without a
+  scheme uses HTTP/WS. Exec and file transfer continue to use
+  `AKERNEL_SERVER_ADDRESS`.
 
 The legacy actor backend is optional. Install and select it before importing
 `akernel_sdk`:

--- a/sdk/python/akernel_sdk/_addresses.py
+++ b/sdk/python/akernel_sdk/_addresses.py
@@ -152,15 +152,7 @@ def gateway_endpoint_from_env() -> Endpoint:
 def exec_endpoint_from_env() -> Endpoint:
     """Return the endpoint used by the exec WebSocket (/terminal/ws).
 
-    File copy and PTY traffic use an explicit AKERNEL gateway override when
-    configured; otherwise they use the API endpoint.  The default
-    cluster/public path is therefore WSS on 443 or the explicit server port.
+    File copy and PTY traffic terminate on the frontend alongside the API, so
+    they always follow AKERNEL_SERVER_ADDRESS.
     """
-    override = os.environ.get("AKERNEL_GATEWAY_ADDRESS", "").strip()
-    if override:
-        return _parse_endpoint(
-            override,
-            default_port=DEFAULT_PUBLIC_PORT,
-            default_scheme="http",
-        )
     return api_endpoint_from_env()

--- a/sdk/python/akernel_sdk/_backends/openyuanrong_sdk_filesystem.py
+++ b/sdk/python/akernel_sdk/_backends/openyuanrong_sdk_filesystem.py
@@ -157,9 +157,8 @@ class Filesystem:
 
     def _get_connection(self) -> tuple[str, str, str, str, bool]:
         # File copy is implemented by the frontend exec WebSocket
-        # (/terminal/ws).  By default it follows AKERNEL_SERVER_ADDRESS and
-        # uses TLS; standalone or custom topologies can override it with
-        # AKERNEL_GATEWAY_ADDRESS/YR_GATEWAY_ADDRESS.
+        # (/terminal/ws), so it follows AKERNEL_SERVER_ADDRESS and uses the
+        # same TLS setting as the frontend API.
         endpoint = exec_endpoint_from_env()
         instance_id = self._instance_id
         if not instance_id:

--- a/sdk/python/tests/unit/test_addresses.py
+++ b/sdk/python/tests/unit/test_addresses.py
@@ -55,7 +55,7 @@ class AddressConfigTest(unittest.TestCase):
                 endpoint_tuple(gateway_endpoint_from_env()), gateway_expected
             )
 
-    def test_gateway_override_defaults_to_plain_http(self):
+    def test_gateway_override_only_affects_public_gateway(self):
         with patch.dict(
             os.environ,
             {
@@ -64,9 +64,14 @@ class AddressConfigTest(unittest.TestCase):
             },
             clear=True,
         ):
-            expected = ("http", "127.0.0.1", 8081, False)
-            self.assertEqual(endpoint_tuple(exec_endpoint_from_env()), expected)
-            self.assertEqual(endpoint_tuple(gateway_endpoint_from_env()), expected)
+            self.assertEqual(
+                endpoint_tuple(exec_endpoint_from_env()),
+                ("https", "10.0.0.1", 8888, True),
+            )
+            self.assertEqual(
+                endpoint_tuple(gateway_endpoint_from_env()),
+                ("http", "127.0.0.1", 8081, False),
+            )
 
     def test_gateway_override_respects_scheme(self):
         with patch.dict(
@@ -78,7 +83,7 @@ class AddressConfigTest(unittest.TestCase):
             clear=True,
         ):
             self.assertEqual(
-                endpoint_tuple(exec_endpoint_from_env()),
+                endpoint_tuple(gateway_endpoint_from_env()),
                 ("https", "gw.example.com", 9443, True),
             )
 


### PR DESCRIPTION
## Summary

- keep PTY and file-transfer WebSockets on `AKERNEL_SERVER_ADDRESS`
- reserve `AKERNEL_GATEWAY_ADDRESS` for port forwarding and reverse tunnels
- document the endpoint responsibilities and add regression coverage

## Problem

An explicit plain-HTTP gateway currently redirects `/terminal/ws` traffic
away from the TLS frontend. Deployments that need a separate public gateway
therefore cannot configure port forwarding without breaking `ak exec` and
file transfer with an HTTP 404.

This change makes exec traffic consistently follow the frontend API endpoint
while preserving the existing gateway behavior for public sandbox ports and
reverse tunnels.

## Testing

- `make sdk-check` (245 tests, Ruff, mypy)
