### PR TITLE
chore(release): prepare Python SDK 0.1.6rc1

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -35,8 +35,8 @@ jobs:
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Release tag must use the stable vX.Y.Z format: ${RELEASE_TAG}" >&2
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$ ]]; then
+            echo "Release tag must use vX.Y.Z or vX.Y.ZrcN: ${RELEASE_TAG}" >&2
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -454,9 +454,10 @@ are not part of the default test suite.
 
 ## Release
 
-Python SDK releases use stable `vX.Y.Z` tags. The tag version must match the
-version in `sdk/python/pyproject.toml`, and the tagged commit must be part of
-`main`. Publishing a GitHub Release runs
+Python SDK releases use stable `vX.Y.Z` tags or release-candidate
+`vX.Y.ZrcN` tags. The tag version must match the version in
+`sdk/python/pyproject.toml`, and the tagged commit must be part of `main`.
+Publishing a GitHub Release runs
 `.github/workflows/release-python.yml`, which checks the SDK, builds and tests
 the wheel and source distribution, and publishes them through the PyPI trusted
 publisher configured for the `pypi` GitHub environment. Do not add a PyPI

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "akernel-sdk"
-version = "0.1.5"
+version = "0.1.6rc1"
 description = "Python SDK and CLI for AKernel remote sandboxes"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- bump `akernel-sdk` to `0.1.6rc1`
- accept canonical `vX.Y.ZrcN` release tags in the publishing workflow

## Validation

- `make sdk-check`
- built the wheel and source distribution with version `0.1.6rc1`