### PR TITLE
fix(deploy): configure aggregate PID budgets for ACK runtime pools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,9 @@ Use [`deploy/README.md`](./deploy/README.md) as the deployment entry point.
 AKernel supports standalone, existing Kubernetes clusters via Helm, and
 Terraform-based cloud provisioning.
 
+Aliyun's aggregate Pod PID budget is configurable independently of the
+per-sandbox limit; see `deploy/terraform/aliyun/README.md#pod-pid-budget`.
+
 For guided cloud deployment:
 
 ```bash

--- a/deploy/terraform/aliyun/README.md
+++ b/deploy/terraform/aliyun/README.md
@@ -10,6 +10,17 @@ It installs:
 - Optional Dragonfly to `dragonfly_namespace` (controlled by `install_dragonfly`)
 - Optional prereq `openkruise` to `prereq_namespace` (controlled by `install_prereqs`)
 
+## Pod PID budget
+
+`node_pool_pids_limit` defaults to `1620780` for the default pool and all
+user-supplied `extra_node_pools`; generated Dragonfly pools are excluded.
+Override it in `terraform.tfvars` with a positive integer or `-1` (node
+allocatable PID capacity). All sandboxes and runtime services share this
+budget; the per-sandbox limit stays 4096. Size it for node capacity and monitor
+memory pressure. Existing clusters require separate kubelet configuration.
+Review rollout impact before applying, then verify actual Pod and ancestor
+`pids.max` values: a kubelet config update alone may leave existing Pods stale.
+
 ## Prerequisites
 - Terraform >= 1.5
 - Alibaba Cloud account permissions for VPC/VSwitch/ACK/RAM resources

--- a/deploy/terraform/aliyun/main.tf
+++ b/deploy/terraform/aliyun/main.tf
@@ -246,6 +246,7 @@ locals {
 
   akernel_extra_node_pools = [for pool in var.extra_node_pools : merge(pool, {
     use_akernel_data_disk = true
+    pod_pids_limit        = var.node_pool_pids_limit
   })]
 
   # Dragonfly server pool (manager + scheduler) — fixed size, goes through extra node pools
@@ -257,6 +258,7 @@ locals {
     data_disk_enabled     = true
     data_disk_size        = var.dragonfly_server_node_pool.data_disk_size
     use_akernel_data_disk = false
+    pod_pids_limit        = null
     labels = {
       (var.dragonfly_server_node_pool.node_label_key) = var.dragonfly_server_node_pool.node_label_value
     }
@@ -421,6 +423,10 @@ resource "alicloud_cs_kubernetes_node_pool" "default_with_key" {
   cluster_id     = alicloud_cs_managed_kubernetes.ack[0].id
   node_pool_name = "${var.cluster_name}-default"
 
+  kubelet_configuration {
+    pod_pids_limit = tostring(var.node_pool_pids_limit)
+  }
+
   vswitch_ids        = local.node_pool_vswitch_ids
   security_group_ids = length(var.node_pool_security_group_ids) > 0 ? var.node_pool_security_group_ids : null
   instance_types     = var.node_pool_instance_types
@@ -465,6 +471,10 @@ resource "alicloud_cs_kubernetes_node_pool" "default_with_password" {
   count          = var.create_cluster && length(var.node_pool_key_name) == 0 ? 1 : 0
   cluster_id     = alicloud_cs_managed_kubernetes.ack[0].id
   node_pool_name = "${var.cluster_name}-default"
+
+  kubelet_configuration {
+    pod_pids_limit = tostring(var.node_pool_pids_limit)
+  }
 
   vswitch_ids        = local.node_pool_vswitch_ids
   security_group_ids = length(var.node_pool_security_group_ids) > 0 ? var.node_pool_security_group_ids : null
@@ -514,6 +524,13 @@ resource "alicloud_cs_kubernetes_node_pool" "extra" {
 
   cluster_id     = alicloud_cs_managed_kubernetes.ack[0].id
   node_pool_name = "${var.cluster_name}-${each.key}"
+
+  dynamic "kubelet_configuration" {
+    for_each = each.value.pod_pids_limit == null ? [] : [each.value.pod_pids_limit]
+    content {
+      pod_pids_limit = tostring(kubelet_configuration.value)
+    }
+  }
 
   vswitch_ids        = local.node_pool_vswitch_ids
   security_group_ids = length(var.node_pool_security_group_ids) > 0 ? var.node_pool_security_group_ids : null

--- a/deploy/terraform/aliyun/terraform.tfvars.example
+++ b/deploy/terraform/aliyun/terraform.tfvars.example
@@ -51,6 +51,8 @@ node_pool_image_type           = "AliyunLinux3"
 # Optional: pin node pool to one zone in zone_ids.
 # node_pool_zone_id            = "cn-hangzhou-i"
 node_pool_size                 = 3
+# Shared per-Pod budget; the per-sandbox pids_max remains 4096.
+node_pool_pids_limit            = 1620780
 node_pool_system_disk_category = "cloud_essd"
 node_pool_system_disk_size     = 100
 node_pool_data_disk_enabled    = true

--- a/deploy/terraform/aliyun/variables.tf
+++ b/deploy/terraform/aliyun/variables.tf
@@ -199,6 +199,18 @@ variable "node_pool_zone_id" {
   default     = ""
 }
 
+variable "node_pool_pids_limit" {
+  type        = number
+  description = "Per-Pod PID budget for the default and user-supplied extra ACK node pools, shared by all sandboxes and runtime services."
+  default     = 1620780
+  nullable    = false
+
+  validation {
+    condition     = var.node_pool_pids_limit == -1 || (var.node_pool_pids_limit > 0 && floor(var.node_pool_pids_limit) == var.node_pool_pids_limit)
+    error_message = "node_pool_pids_limit must be a positive integer or -1 (node allocatable PID capacity)."
+  }
+}
+
 variable "node_pool_size" {
   type        = number
   description = "Desired node count in the default node pool."

--- a/deploy/terraform/huaweicloud/README.md
+++ b/deploy/terraform/huaweicloud/README.md
@@ -6,6 +6,13 @@ contract as the Aliyun module: one all-in-one AKernel image, a generated IAM
 seed, dual-entrypoint Traefik, optional public Grafana, and local state under
 `.akernel/<env>/`.
 
+## Pod PID budget
+
+[CCE documents `pod-pids-limit=-1` by default](https://support.huaweicloud.com/intl/en-us/usermanual-cce/cce_10_0652.html),
+so no ACK-specific override is applied. For customized pools, verify actual
+Pod and ancestor PID limits and adjust via CCE node pool configuration if
+needed. The per-sandbox limit remains 4096.
+
 ## Prerequisites
 
 - Terraform 1.5 or later


### PR DESCRIPTION
## Summary

ACK's default per-Pod PID quota can be exhausted by the combined sandbox
workloads and runtime services even when each sandbox stays below its own
4096 limit.

This change sets a configurable `node_pool_pids_limit` of `1620780` for the
default and user-supplied extra ACK node pools. Generated Dragonfly pools
and the per-sandbox limit remain unchanged. It also adds brief guidance on
configuration overrides and verifying actual Pod limits after rollout.

Huawei Cloud CCE documents a default of `pod-pids-limit=-1`, so its deployment
configuration is left unchanged and the difference is documented.

## Validation

- `terraform fmt -check` on the modified Terraform configuration
- `terraform -chdir=deploy/terraform/aliyun validate -no-color`
- `git diff --check`

No cloud resources were modified as part of this change.
